### PR TITLE
Implement BusinessUnitApiClient

### DIFF
--- a/Farmacheck.Infrastructure/Interfaces/IBusinessUnitApiClient.cs
+++ b/Farmacheck.Infrastructure/Interfaces/IBusinessUnitApiClient.cs
@@ -1,0 +1,14 @@
+using Farmacheck.Infrastructure.Models.BusinessUnits;
+
+namespace Farmacheck.Infrastructure.Interfaces
+{
+    public interface IBusinessUnitApiClient
+    {
+        Task<List<BusinessUnitResponse>> GetBusinessUnitsAsync();
+        Task<List<BusinessUnitResponse>> GetBusinessUnitsByPageAsync(int page, int items);
+        Task<BusinessUnitResponse?> GetBusinessUnitAsync(int id);
+        Task<int> CreateAsync(BusinessUnitRequest request);
+        Task<bool> UpdateAsync(BusinessUnitRequest request);
+        Task DeleteAsync(int id);
+    }
+}

--- a/Farmacheck.Infrastructure/Models/BusinessUnits/BusinessUnitRequest.cs
+++ b/Farmacheck.Infrastructure/Models/BusinessUnits/BusinessUnitRequest.cs
@@ -1,0 +1,10 @@
+namespace Farmacheck.Infrastructure.Models.BusinessUnits
+{
+    public class BusinessUnitRequest
+    {
+        public string Nombre { get; set; } = null!;
+        public string? Rfc { get; set; }
+        public string? Direccion { get; set; }
+        public string? Logotipo { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/Models/BusinessUnits/BusinessUnitResponse.cs
+++ b/Farmacheck.Infrastructure/Models/BusinessUnits/BusinessUnitResponse.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Farmacheck.Infrastructure.Models.BusinessUnits
+{
+    public class BusinessUnitResponse
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public string? Rfc { get; set; }
+        public string? Direccion { get; set; }
+        public string? Logotipo { get; set; }
+        public DateTime? ModificadaEl { get; set; }
+        public bool? Estatus { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/Services/BusinessUnitApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/BusinessUnitApiClient.cs
@@ -1,0 +1,55 @@
+using Farmacheck.Infrastructure.Interfaces;
+using Farmacheck.Infrastructure.Models.BusinessUnits;
+using System.Net.Http.Json;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    public class BusinessUnitApiClient : IBusinessUnitApiClient
+    {
+        private readonly HttpClient _http;
+
+        public BusinessUnitApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<BusinessUnitResponse>> GetBusinessUnitsAsync()
+        {
+            return await _http.GetFromJsonAsync<List<BusinessUnitResponse>>("api/v1/BusinessUnits")
+                   ?? new List<BusinessUnitResponse>();
+        }
+
+        public async Task<List<BusinessUnitResponse>> GetBusinessUnitsByPageAsync(int page, int items)
+        {
+            var url = $"api/v1/BusinessUnits/pages?page={page}&items={items}";
+            return await _http.GetFromJsonAsync<List<BusinessUnitResponse>>(url) ?? new List<BusinessUnitResponse>();
+        }
+
+        public async Task<BusinessUnitResponse?> GetBusinessUnitAsync(int id)
+        {
+            return await _http.GetFromJsonAsync<BusinessUnitResponse>($"api/v1/BusinessUnits/{id}");
+        }
+
+        public async Task<int> CreateAsync(BusinessUnitRequest request)
+        {
+            var response = await _http.PostAsJsonAsync("api/v1/BusinessUnits", request);
+            response.EnsureSuccessStatusCode();
+            var id = await response.Content.ReadFromJsonAsync<int>();
+            return id;
+        }
+
+        public async Task<bool> UpdateAsync(BusinessUnitRequest request)
+        {
+            var response = await _http.PutAsJsonAsync("api/v1/BusinessUnits", request);
+            response.EnsureSuccessStatusCode();
+            var updated = await response.Content.ReadFromJsonAsync<bool>();
+            return updated;
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            var response = await _http.DeleteAsync($"api/v1/BusinessUnits/{id}");
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -22,6 +22,11 @@ namespace Farmacheck
                 client.BaseAddress = new Uri(builder.Configuration["BrandApi:BaseUrl"]!);
             });
 
+            builder.Services.AddHttpClient<IBusinessUnitApiClient, BusinessUnitApiClient>(client =>
+            {
+                client.BaseAddress = new Uri(builder.Configuration["BusinessUnitApi:BaseUrl"]!);
+            });
+
             var app = builder.Build();
 
             // Configure the HTTP request pipeline.

--- a/Farmacheck/appsettings.json
+++ b/Farmacheck/appsettings.json
@@ -6,7 +6,10 @@
     }
   },
   "AllowedHosts": "*",
-  "BrandApi": {   
+  "BrandApi": {
+    "BaseUrl": "https://localhost:7205/"
+  },
+  "BusinessUnitApi": {
     "BaseUrl": "https://localhost:7205/"
   }
 }


### PR DESCRIPTION
## Summary
- add models for business unit requests and responses
- create `IBusinessUnitApiClient` with CRUD methods
- implement `BusinessUnitApiClient`
- register the new client in DI
- add configuration section for BusinessUnitApi

## Testing
- `dotnet build Farmacheck/Farmacheck.sln -c Release` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686712300318833187a76f6106403fe0