### PR TITLE
Connect SubMarca controller with API client

### DIFF
--- a/Farmacheck.Application/DTOs/SubmarcaDto.cs
+++ b/Farmacheck.Application/DTOs/SubmarcaDto.cs
@@ -1,16 +1,13 @@
-namespace Farmacheck.Models
+using System;
+
+namespace Farmacheck.Application.DTOs
 {
-    public class SubMarca
+    public class SubmarcaDto
     {
         public int Id { get; set; }
         public int MarcaId { get; set; }
-        public string Nombre { get; set; }
-
-        public string? MarcaNombre { get; set; }
-
+        public string Nombre { get; set; } = null!;
         public bool? Estatus { get; set; }
-
         public DateTime? ModificadaEl { get; set; }
-
     }
 }

--- a/Farmacheck.Application/Mappings/SubbrandProfile.cs
+++ b/Farmacheck.Application/Mappings/SubbrandProfile.cs
@@ -1,0 +1,21 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Infrastructure.Models.SubBrands;
+
+namespace Farmacheck.Application.Mappings
+{
+    public class SubbrandProfile : Profile
+    {
+        public SubbrandProfile()
+        {
+            CreateMap<SubbrandResponse, SubmarcaDto>()
+                .ForMember(dest => dest.MarcaId, opt => opt.MapFrom(src => src.Marca));
+
+            CreateMap<SubmarcaDto, SubbrandRequest>()
+                .ForMember(dest => dest.MarcaId, opt => opt.MapFrom(src => src.MarcaId));
+
+            CreateMap<SubmarcaDto, UpdateSubbrandRequest>()
+                .ForMember(dest => dest.MarcaId, opt => opt.MapFrom(src => src.MarcaId));
+        }
+    }
+}

--- a/Farmacheck/Helpers/WebMappingProfile.cs
+++ b/Farmacheck/Helpers/WebMappingProfile.cs
@@ -3,7 +3,7 @@ using Farmacheck.Application.DTOs;
 using Farmacheck.Infrastructure.Models.BusinessUnits;
 using Farmacheck.Models;
 using Farmacheck.Infrastructure.Models.Brands;
-//using Farmacheck.Infrastructure.Models.Brands;
+using Farmacheck.Infrastructure.Models.SubBrands;
 
 namespace Farmacheck.Helpers
 {
@@ -21,6 +21,11 @@ namespace Farmacheck.Helpers
             .ForMember(dest => dest.Logotipo, opt => opt.MapFrom(src => src.Logotipo ?? string.Empty))
             .ForMember(dest => dest.Rfc, opt => opt.MapFrom(src => src.Rfc ?? string.Empty))
             .ForMember(dest => dest.Direccion, opt => opt.MapFrom(src => src.Direccion ?? string.Empty));
+
+
+            CreateMap<SubmarcaDto, SubMarca>();
+            CreateMap<SubMarca, SubbrandRequest>();
+            CreateMap<SubMarca, UpdateSubbrandRequest>();
 
 
             CreateMap<UnidadDeNegocio, BusinessUnitRequest>()

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -15,7 +15,7 @@ namespace Farmacheck
 
             //builder.Services.AddAutoMapper(typeof(BrandProfile).Assembly);
             //builder.Services.AddAutoMapper(typeof(WebMappingProfile), typeof(BrandProfile));
-            builder.Services.AddAutoMapper(typeof(WebMappingProfile), typeof(BrandProfile), typeof(BusinessUnitProfile));
+            builder.Services.AddAutoMapper(typeof(WebMappingProfile), typeof(BrandProfile), typeof(BusinessUnitProfile), typeof(SubbrandProfile));
 
             builder.Services.AddHttpClient<IBrandApiClient, BrandApiClient>(client =>
             {
@@ -25,6 +25,11 @@ namespace Farmacheck
             builder.Services.AddHttpClient<IBusinessUnitApiClient, BusinessUnitApiClient>(client =>
             {
                 client.BaseAddress = new Uri(builder.Configuration["BusinessUnitApi:BaseUrl"]!);
+            });
+
+            builder.Services.AddHttpClient<ISubbrandApiClient, SubbrandApiClient>(client =>
+            {
+                client.BaseAddress = new Uri(builder.Configuration["SubbrandApi:BaseUrl"]!);
             });
 
             var app = builder.Build();

--- a/Farmacheck/appsettings.json
+++ b/Farmacheck/appsettings.json
@@ -11,5 +11,8 @@
   },
   "BusinessUnitApi": {
     "BaseUrl": "https://localhost:7205/"
+  },
+  "SubbrandApi": {
+    "BaseUrl": "https://localhost:7205/"
   }
 }


### PR DESCRIPTION
## Summary
- add SubmarcaDto and mapping profile
- map SubMarca to infrastructure requests
- integrate SubMarcaController with SubbrandApiClient
- register SubbrandApiClient service and profile
- include SubbrandApi settings
- expose brand name for sub-brand in view model

## Testing
- `dotnet build Farmacheck/Farmacheck.sln -warnaserror` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868b0a073f48331beead3091c64a738