### PR TITLE
Add CustomerTypes API client

### DIFF
--- a/Farmacheck.Infrastructure/Interfaces/ICustomerTypesApiClient.cs
+++ b/Farmacheck.Infrastructure/Interfaces/ICustomerTypesApiClient.cs
@@ -1,0 +1,14 @@
+using Farmacheck.Infrastructure.Models.CustomerTypes;
+
+namespace Farmacheck.Infrastructure.Interfaces
+{
+    public interface ICustomerTypesApiClient
+    {
+        Task<List<CustomerTypeResponse>> GetCustomerTypesAsync();
+        Task<List<CustomerTypeResponse>> GetCustomerTypesByPageAsync(int page, int items);
+        Task<CustomerTypeResponse?> GetCustomerTypeAsync(int id);
+        Task<int> CreateAsync(CustomerTypeRequest request);
+        Task<bool> UpdateAsync(UpdateCustomerTypeRequest request);
+        Task DeleteAsync(int id);
+    }
+}

--- a/Farmacheck.Infrastructure/Models/CustomerTypes/CustomerTypeRequest.cs
+++ b/Farmacheck.Infrastructure/Models/CustomerTypes/CustomerTypeRequest.cs
@@ -1,0 +1,7 @@
+namespace Farmacheck.Infrastructure.Models.CustomerTypes
+{
+    public class CustomerTypeRequest
+    {
+        public string Nombre { get; set; } = null!;
+    }
+}

--- a/Farmacheck.Infrastructure/Models/CustomerTypes/CustomerTypeResponse.cs
+++ b/Farmacheck.Infrastructure/Models/CustomerTypes/CustomerTypeResponse.cs
@@ -1,0 +1,10 @@
+namespace Farmacheck.Infrastructure.Models.CustomerTypes
+{
+    public class CustomerTypeResponse
+    {
+        public short Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public bool? Estatus { get; set; }
+        public DateTime? ModificadoEl { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/Models/CustomerTypes/UpdateCustomerTypeRequest.cs
+++ b/Farmacheck.Infrastructure/Models/CustomerTypes/UpdateCustomerTypeRequest.cs
@@ -1,0 +1,8 @@
+namespace Farmacheck.Infrastructure.Models.CustomerTypes
+{
+    public class UpdateCustomerTypeRequest : CustomerTypeRequest
+    {
+        public short Id { get; set; }
+        public bool? Estatus { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/Services/CustomerTypesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CustomerTypesApiClient.cs
@@ -1,0 +1,56 @@
+using Farmacheck.Infrastructure.Interfaces;
+using Farmacheck.Infrastructure.Models.CustomerTypes;
+using System.Net.Http.Json;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    public class CustomerTypesApiClient : ICustomerTypesApiClient
+    {
+        private readonly HttpClient _http;
+
+        public CustomerTypesApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<CustomerTypeResponse>> GetCustomerTypesAsync()
+        {
+            return await _http.GetFromJsonAsync<List<CustomerTypeResponse>>("api/v1/CustomerTypes")
+                   ?? new List<CustomerTypeResponse>();
+        }
+
+        public async Task<List<CustomerTypeResponse>> GetCustomerTypesByPageAsync(int page, int items)
+        {
+            var url = $"api/v1/CustomerTypes/pages?page={page}&items={items}";
+            return await _http.GetFromJsonAsync<List<CustomerTypeResponse>>(url)
+                   ?? new List<CustomerTypeResponse>();
+        }
+
+        public async Task<CustomerTypeResponse?> GetCustomerTypeAsync(int id)
+        {
+            return await _http.GetFromJsonAsync<CustomerTypeResponse>($"api/v1/CustomerTypes/{id}");
+        }
+
+        public async Task<int> CreateAsync(CustomerTypeRequest request)
+        {
+            var response = await _http.PostAsJsonAsync("api/v1/CustomerTypes", request);
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadFromJsonAsync<int>();
+        }
+
+        public async Task<bool> UpdateAsync(UpdateCustomerTypeRequest request)
+        {
+            var response = await _http.PutAsJsonAsync("api/v1/CustomerTypes", request);
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadFromJsonAsync<bool>();
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            var response = await _http.DeleteAsync($"api/v1/CustomerTypes/{id}");
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create customer type models in Infrastructure layer
- add `ICustomerTypesApiClient` interface
- implement `CustomerTypesApiClient` service

## Testing
- `dotnet build Farmacheck/Farmacheck.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b553124e88331a0f258bb0e6b1115