### PR TITLE
Add Zones API client

### DIFF
--- a/Farmacheck.Infrastructure/Interfaces/IZoneApiClient.cs
+++ b/Farmacheck.Infrastructure/Interfaces/IZoneApiClient.cs
@@ -1,0 +1,14 @@
+using Farmacheck.Infrastructure.Models.Zones;
+
+namespace Farmacheck.Infrastructure.Interfaces
+{
+    public interface IZoneApiClient
+    {
+        Task<List<ZoneResponse>> GetZonesAsync();
+        Task<List<ZoneResponse>> GetZonesByPageAsync(int page, int items);
+        Task<ZoneResponse?> GetZoneAsync(int id);
+        Task<int> CreateAsync(ZoneRequest request);
+        Task<bool> UpdateAsync(UpdateZoneRequest request);
+        Task DeleteAsync(int id);
+    }
+}

--- a/Farmacheck.Infrastructure/Models/Zones/UpdateZoneRequest.cs
+++ b/Farmacheck.Infrastructure/Models/Zones/UpdateZoneRequest.cs
@@ -1,0 +1,8 @@
+namespace Farmacheck.Infrastructure.Models.Zones
+{
+    public class UpdateZoneRequest : ZoneRequest
+    {
+        public int Id { get; set; }
+        public bool? Estatus { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/Models/Zones/ZoneRequest.cs
+++ b/Farmacheck.Infrastructure/Models/Zones/ZoneRequest.cs
@@ -1,0 +1,7 @@
+namespace Farmacheck.Infrastructure.Models.Zones
+{
+    public class ZoneRequest
+    {
+        public string Nombre { get; set; } = null!;
+    }
+}

--- a/Farmacheck.Infrastructure/Models/Zones/ZoneResponse.cs
+++ b/Farmacheck.Infrastructure/Models/Zones/ZoneResponse.cs
@@ -1,0 +1,11 @@
+using System;
+namespace Farmacheck.Infrastructure.Models.Zones
+{
+    public class ZoneResponse
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public bool? Estatus { get; set; }
+        public DateTime? ModificadaEl { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/Services/ZonesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/ZonesApiClient.cs
@@ -1,0 +1,54 @@
+using Farmacheck.Infrastructure.Interfaces;
+using Farmacheck.Infrastructure.Models.Zones;
+using System.Net.Http.Json;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    public class ZonesApiClient : IZoneApiClient
+    {
+        private readonly HttpClient _http;
+
+        public ZonesApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<ZoneResponse>> GetZonesAsync()
+        {
+            return await _http.GetFromJsonAsync<List<ZoneResponse>>("api/v1/Zones")
+                   ?? new List<ZoneResponse>();
+        }
+
+        public async Task<List<ZoneResponse>> GetZonesByPageAsync(int page, int items)
+        {
+            var url = $"api/v1/Zones/pages?page={page}&items={items}";
+            return await _http.GetFromJsonAsync<List<ZoneResponse>>(url)
+                   ?? new List<ZoneResponse>();
+        }
+
+        public async Task<ZoneResponse?> GetZoneAsync(int id)
+        {
+            return await _http.GetFromJsonAsync<ZoneResponse>($"api/v1/Zones/{id}");
+        }
+
+        public async Task<int> CreateAsync(ZoneRequest request)
+        {
+            var response = await _http.PostAsJsonAsync("api/v1/Zones", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<int>();
+        }
+
+        public async Task<bool> UpdateAsync(UpdateZoneRequest request)
+        {
+            var response = await _http.PutAsJsonAsync("api/v1/Zones", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<bool>();
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            var response = await _http.DeleteAsync($"api/v1/Zones/{id}");
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -37,6 +37,11 @@ namespace Farmacheck
                 client.BaseAddress = new Uri(builder.Configuration["CustomersApi:BaseUrl"]!);
             });
 
+            builder.Services.AddHttpClient<IZoneApiClient, ZonesApiClient>(client =>
+            {
+                client.BaseAddress = new Uri(builder.Configuration["ZonesApi:BaseUrl"]!);
+            });
+
             var app = builder.Build();
 
             // Configure the HTTP request pipeline.


### PR DESCRIPTION
## Summary
- implement `IZoneApiClient` interface and its model classes under Infrastructure
- implement `ZonesApiClient` service for calls to the Zones API
- register the new client in `Program.cs`

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b5782b2488331905e7a9793cbac1a