### PR TITLE
Integrate dynamic customer type and zone catalogs

### DIFF
--- a/Farmacheck.Application/DTOs/CustomerTypeDto.cs
+++ b/Farmacheck.Application/DTOs/CustomerTypeDto.cs
@@ -1,0 +1,8 @@
+namespace Farmacheck.Application.DTOs
+{
+    public class CustomerTypeDto
+    {
+        public short Id { get; set; }
+        public string Nombre { get; set; } = null!;
+    }
+}

--- a/Farmacheck.Application/DTOs/ZoneDto.cs
+++ b/Farmacheck.Application/DTOs/ZoneDto.cs
@@ -1,0 +1,8 @@
+namespace Farmacheck.Application.DTOs
+{
+    public class ZoneDto
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+    }
+}

--- a/Farmacheck.Application/Mappings/CustomerTypeProfile.cs
+++ b/Farmacheck.Application/Mappings/CustomerTypeProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Infrastructure.Models.CustomerTypes;
+
+namespace Farmacheck.Application.Mappings
+{
+    public class CustomerTypeProfile : Profile
+    {
+        public CustomerTypeProfile()
+        {
+            CreateMap<CustomerTypeResponse, CustomerTypeDto>();
+        }
+    }
+}

--- a/Farmacheck.Application/Mappings/ZoneProfile.cs
+++ b/Farmacheck.Application/Mappings/ZoneProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Infrastructure.Models.Zones;
+
+namespace Farmacheck.Application.Mappings
+{
+    public class ZoneProfile : Profile
+    {
+        public ZoneProfile()
+        {
+            CreateMap<ZoneResponse, ZoneDto>();
+        }
+    }
+}

--- a/Farmacheck/Controllers/ClienteController.cs
+++ b/Farmacheck/Controllers/ClienteController.cs
@@ -13,22 +13,19 @@ namespace Farmacheck.Controllers
     public class ClienteController : Controller
     {
         private readonly ICustomersApiClient _apiClient;
+        private readonly ICustomerTypesApiClient _customerTypesApi;
+        private readonly IZoneApiClient _zoneApi;
         private readonly IMapper _mapper;
 
-        private static readonly List<SelectListItem> _tiposCliente = new()
-        {
-            new SelectListItem { Value = "1", Text = "Tipo A" },
-            new SelectListItem { Value = "2", Text = "Tipo B" }
-        };
-
-        private static readonly List<SelectListItem> _zonas = new()
-        {
-            new SelectListItem { Value = "1", Text = "Zona Norte" },
-            new SelectListItem { Value = "2", Text = "Zona Sur" }
-        };
-        public ClienteController(ICustomersApiClient apiClient, IMapper mapper)
+        public ClienteController(
+            ICustomersApiClient apiClient,
+            ICustomerTypesApiClient customerTypesApi,
+            IZoneApiClient zoneApi,
+            IMapper mapper)
         {
             _apiClient = apiClient;
+            _customerTypesApi = customerTypesApi;
+            _zoneApi = zoneApi;
             _mapper = mapper;
         }
 
@@ -93,15 +90,21 @@ namespace Farmacheck.Controllers
 
 
         [HttpGet]
-        public JsonResult ListarTiposCliente()
+        public async Task<JsonResult> ListarTiposCliente()
         {
-            return Json(new { success = true, data = _tiposCliente });
+            var apiData = await _customerTypesApi.GetCustomerTypesAsync();
+            var dtos = _mapper.Map<List<CustomerTypeDto>>(apiData);
+            var items = _mapper.Map<List<SelectListItem>>(dtos);
+            return Json(new { success = true, data = items });
         }
 
         [HttpGet]
-        public JsonResult ListarZonas()
+        public async Task<JsonResult> ListarZonas()
         {
-            return Json(new { success = true, data = _zonas });
+            var apiData = await _zoneApi.GetZonesAsync();
+            var dtos = _mapper.Map<List<ZoneDto>>(apiData);
+            var items = _mapper.Map<List<SelectListItem>>(dtos);
+            return Json(new { success = true, data = items });
         }
     }
 }

--- a/Farmacheck/Helpers/WebMappingProfile.cs
+++ b/Farmacheck/Helpers/WebMappingProfile.cs
@@ -5,6 +5,7 @@ using Farmacheck.Models;
 using Farmacheck.Infrastructure.Models.Brands;
 using Farmacheck.Infrastructure.Models.SubBrands;
 using Farmacheck.Infrastructure.Models.Customers;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace Farmacheck.Helpers
 {
@@ -57,6 +58,14 @@ namespace Farmacheck.Helpers
             .ForMember(dest => dest.Logotipo, opt => opt.MapFrom(src => src.Logotipo ?? string.Empty))
             .ForMember(dest => dest.Rfc, opt => opt.MapFrom(src => src.Rfc ?? string.Empty))
             .ForMember(dest => dest.Direccion, opt => opt.MapFrom(src => src.Direccion ?? string.Empty));
+
+            CreateMap<CustomerTypeDto, SelectListItem>()
+                .ForMember(dest => dest.Value, opt => opt.MapFrom(src => src.Id.ToString()))
+                .ForMember(dest => dest.Text, opt => opt.MapFrom(src => src.Nombre));
+
+            CreateMap<ZoneDto, SelectListItem>()
+                .ForMember(dest => dest.Value, opt => opt.MapFrom(src => src.Id.ToString()))
+                .ForMember(dest => dest.Text, opt => opt.MapFrom(src => src.Nombre));
         }
     }
 }

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -15,7 +15,14 @@ namespace Farmacheck
 
             //builder.Services.AddAutoMapper(typeof(BrandProfile).Assembly);
             //builder.Services.AddAutoMapper(typeof(WebMappingProfile), typeof(BrandProfile));
-            builder.Services.AddAutoMapper(typeof(WebMappingProfile), typeof(BrandProfile), typeof(BusinessUnitProfile), typeof(SubbrandProfile), typeof(CustomerProfile));
+            builder.Services.AddAutoMapper(
+                typeof(WebMappingProfile),
+                typeof(BrandProfile),
+                typeof(BusinessUnitProfile),
+                typeof(SubbrandProfile),
+                typeof(CustomerProfile),
+                typeof(CustomerTypeProfile),
+                typeof(ZoneProfile));
 
             builder.Services.AddHttpClient<IBrandApiClient, BrandApiClient>(client =>
             {
@@ -35,6 +42,11 @@ namespace Farmacheck
             builder.Services.AddHttpClient<ICustomersApiClient, CustomersApiClient>(client =>
             {
                 client.BaseAddress = new Uri(builder.Configuration["CustomersApi:BaseUrl"]!);
+            });
+
+            builder.Services.AddHttpClient<ICustomerTypesApiClient, CustomerTypesApiClient>(client =>
+            {
+                client.BaseAddress = new Uri(builder.Configuration["CustomerTypesApi:BaseUrl"]!);
             });
 
             builder.Services.AddHttpClient<IZoneApiClient, ZonesApiClient>(client =>

--- a/Farmacheck/appsettings.json
+++ b/Farmacheck/appsettings.json
@@ -18,7 +18,10 @@
   "CustomersApi": {
     "BaseUrl": "https://localhost:7205" 
   },
-  "CustomerTypes": {
-    "BaseUrl": "https://localhost:7205" 
+  "CustomerTypesApi": {
+    "BaseUrl": "https://localhost:7205"
+  },
+  "ZonesApi": {
+    "BaseUrl": "https://localhost:7205"
   }
 }


### PR DESCRIPTION
## Summary
- support zone and customer type catalogs
- map new entities via AutoMapper
- update ClienteController to fetch catalogs from API
- register new API clients and profiles
- update configuration with base URLs

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b5ac5bd6c83319d6fa2c4ba4cdf28