### PR TITLE
Add BusinessStructureApiClient service

### DIFF
--- a/Farmacheck.Infrastructure/Interfaces/IBusinessStructureApiClient.cs
+++ b/Farmacheck.Infrastructure/Interfaces/IBusinessStructureApiClient.cs
@@ -1,0 +1,15 @@
+using Farmacheck.Infrastructure.Models.BusinessStructures;
+
+namespace Farmacheck.Infrastructure.Interfaces
+{
+    public interface IBusinessStructureApiClient
+    {
+        Task<List<BusinessStructureResponse>> GetBusinessStructuresAsync();
+        Task<List<BusinessStructureResponse>> GetBusinessStructuresByPageAsync(int page, int items);
+        Task<BusinessStructureResponse?> GetBusinessStructureAsync(int id);
+        Task<List<BusinessStructureResponse>> GetBusinessStructuresByCustomerAsync(int customerId);
+        Task<int> CreateAsync(BusinessStructureRequest request);
+        Task<bool> UpdateAsync(UpdateBusinessStructureRequest request);
+        Task DeleteAsync(int id);
+    }
+}

--- a/Farmacheck.Infrastructure/Models/BusinessStructures/BusinessStructureRequest.cs
+++ b/Farmacheck.Infrastructure/Models/BusinessStructures/BusinessStructureRequest.cs
@@ -1,0 +1,10 @@
+namespace Farmacheck.Infrastructure.Models.BusinessStructures
+{
+    public class BusinessStructureRequest
+    {
+        public int ClienteId { get; set; }
+        public int MarcaId { get; set; }
+        public int? SubmarcaId { get; set; }
+        public int ZonaId { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/Models/BusinessStructures/BusinessStructureResponse.cs
+++ b/Farmacheck.Infrastructure/Models/BusinessStructures/BusinessStructureResponse.cs
@@ -1,0 +1,12 @@
+namespace Farmacheck.Infrastructure.Models.BusinessStructures
+{
+    public class BusinessStructureResponse
+    {
+        public long ClienteId { get; set; }
+        public int MarcaId { get; set; }
+        public int? SubmarcaId { get; set; }
+        public int ZonaId { get; set; }
+        public bool? Estatus { get; set; }
+        public DateTime? ModificadaEl { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/Models/BusinessStructures/UpdateBusinessStructureRequest.cs
+++ b/Farmacheck.Infrastructure/Models/BusinessStructures/UpdateBusinessStructureRequest.cs
@@ -1,0 +1,7 @@
+namespace Farmacheck.Infrastructure.Models.BusinessStructures
+{
+    public class UpdateBusinessStructureRequest : BusinessStructureRequest
+    {
+        public bool? Estatus { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/Services/BusinessStructureApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/BusinessStructureApiClient.cs
@@ -1,0 +1,61 @@
+using Farmacheck.Infrastructure.Interfaces;
+using Farmacheck.Infrastructure.Models.BusinessStructures;
+using System.Net.Http.Json;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    public class BusinessStructureApiClient : IBusinessStructureApiClient
+    {
+        private readonly HttpClient _http;
+
+        public BusinessStructureApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<BusinessStructureResponse>> GetBusinessStructuresAsync()
+        {
+            return await _http.GetFromJsonAsync<List<BusinessStructureResponse>>("api/v1/BusinessStructure")
+                   ?? new List<BusinessStructureResponse>();
+        }
+
+        public async Task<List<BusinessStructureResponse>> GetBusinessStructuresByPageAsync(int page, int items)
+        {
+            var url = $"api/v1/BusinessStructure/pages?page={page}&items={items}";
+            return await _http.GetFromJsonAsync<List<BusinessStructureResponse>>(url)
+                   ?? new List<BusinessStructureResponse>();
+        }
+
+        public async Task<BusinessStructureResponse?> GetBusinessStructureAsync(int id)
+        {
+            return await _http.GetFromJsonAsync<BusinessStructureResponse>($"api/v1/BusinessStructure/{id}");
+        }
+
+        public async Task<List<BusinessStructureResponse>> GetBusinessStructuresByCustomerAsync(int customerId)
+        {
+            var url = $"api/v1/BusinessStructure/client/{customerId}";
+            return await _http.GetFromJsonAsync<List<BusinessStructureResponse>>(url)
+                   ?? new List<BusinessStructureResponse>();
+        }
+
+        public async Task<int> CreateAsync(BusinessStructureRequest request)
+        {
+            var response = await _http.PostAsJsonAsync("api/v1/BusinessStructure", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<int>();
+        }
+
+        public async Task<bool> UpdateAsync(UpdateBusinessStructureRequest request)
+        {
+            var response = await _http.PutAsJsonAsync("api/v1/BusinessStructure", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<bool>();
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            var response = await _http.DeleteAsync($"api/v1/BusinessStructure/{id}");
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -54,6 +54,11 @@ namespace Farmacheck
                 client.BaseAddress = new Uri(builder.Configuration["ZonesApi:BaseUrl"]!);
             });
 
+            builder.Services.AddHttpClient<IBusinessStructureApiClient, BusinessStructureApiClient>(client =>
+            {
+                client.BaseAddress = new Uri(builder.Configuration["BusinessStructureApi:BaseUrl"]!);
+            });
+
             var app = builder.Build();
 
             // Configure the HTTP request pipeline.

--- a/Farmacheck/appsettings.json
+++ b/Farmacheck/appsettings.json
@@ -23,5 +23,8 @@
   },
   "ZonesApi": {
     "BaseUrl": "https://localhost:7205"
+  },
+  "BusinessStructureApi": {
+    "BaseUrl": "https://localhost:7205"
   }
 }


### PR DESCRIPTION
## Summary
- add BusinessStructure models and interface
- implement BusinessStructureApiClient
- register client in Program.cs
- add BusinessStructureApi configuration

## Testing
- `dotnet build Farmacheck/Farmacheck.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686beaf38d688331aa4c8f828daea948