### PR TITLE
Add business structure updates on client actions

### DIFF
--- a/Farmacheck.Application/DTOs/BusinessStructureRequestDto.cs
+++ b/Farmacheck.Application/DTOs/BusinessStructureRequestDto.cs
@@ -1,0 +1,11 @@
+namespace Farmacheck.Application.DTOs
+{
+    public class BusinessStructureRequestDto
+    {
+        public int ClienteId { get; set; }
+        public int MarcaId { get; set; }
+        public int? SubmarcaId { get; set; }
+        public int ZonaId { get; set; }
+        public bool? Estatus { get; set; }
+    }
+}

--- a/Farmacheck.Application/Mappings/BusinessStructureProfile.cs
+++ b/Farmacheck.Application/Mappings/BusinessStructureProfile.cs
@@ -9,6 +9,20 @@ namespace Farmacheck.Application.Mappings
         public BusinessStructureProfile()
         {
             CreateMap<BusinessStructureResponse, BusinessStructureDto>();
+
+            CreateMap<BusinessStructureDto, BusinessStructureRequest>()
+                .ForMember(dest => dest.MarcaId, opt => opt.MapFrom(src => src.MarcaId))
+                .ForMember(dest => dest.SubmarcaId, opt => opt.MapFrom(src => src.SubmarcaId))
+                .ForMember(dest => dest.ZonaId, opt => opt.MapFrom(src => src.ZonaId))
+                .ForMember(dest => dest.ClienteId, opt => opt.Ignore());
+
+            CreateMap<BusinessStructureDto, UpdateBusinessStructureRequest>()
+                .IncludeBase<BusinessStructureDto, BusinessStructureRequest>();
+
+            CreateMap<BusinessStructureRequestDto, BusinessStructureRequest>();
+
+            CreateMap<BusinessStructureRequestDto, UpdateBusinessStructureRequest>()
+                .IncludeBase<BusinessStructureRequestDto, BusinessStructureRequest>();
         }
     }
 }

--- a/Farmacheck/Controllers/ClienteController.cs
+++ b/Farmacheck/Controllers/ClienteController.cs
@@ -87,7 +87,7 @@ namespace Farmacheck.Controllers
                 {
                     success = false,
                     error = "Ha ocurrido un error inesperado.",
-                    detail = ex.Message // opcional en producción
+                    detail = ex.Message // opcional en producciÃ³n
                 });
             }
         }
@@ -102,6 +102,11 @@ namespace Farmacheck.Controllers
             {
                 var request = _mapper.Map<CustomerRequest>(model);
                 var id = await _apiClient.CreateAsync(request);
+
+                var bsRequest = _mapper.Map<BusinessStructureRequest>(model);
+                bsRequest.ClienteId = id;
+                await _businessStructureApi.CreateAsync(bsRequest);
+
                 return Json(new { success = true, id });
             }
             else
@@ -109,7 +114,13 @@ namespace Farmacheck.Controllers
                 var updateRequest = _mapper.Map<UpdateCustomerRequest>(model);
                 var updated = await _apiClient.UpdateAsync(updateRequest);
                 if (updated)
+                {
+                    var bsUpdate = _mapper.Map<UpdateBusinessStructureRequest>(model);
+                    bsUpdate.ClienteId = model.ClienteId;
+                    await _businessStructureApi.UpdateAsync(bsUpdate);
+
                     return Json(new { success = true, id = model.ClienteId });
+                }
 
                 return Json(new { success = false, error = "No se pudo actualizar" });
             }
@@ -119,6 +130,7 @@ namespace Farmacheck.Controllers
         public async Task<JsonResult> Eliminar(int id)
         {
             await _apiClient.DeleteAsync(id);
+            await _businessStructureApi.DeleteAsync(id);
             return Json(new { success = true });
         }
 

--- a/Farmacheck/Helpers/WebMappingProfile.cs
+++ b/Farmacheck/Helpers/WebMappingProfile.cs
@@ -67,6 +67,16 @@ namespace Farmacheck.Helpers
                 .ForMember(dest => dest.LongitudGps, opt => opt.MapFrom(src => src.LongitudGPS ?? 0))
                 .ForMember(dest => dest.RadioGps, opt => opt.MapFrom(src => (short)(src.RadioGPS ?? 0)));
 
+            CreateMap<ClienteEstructuraViewModel, BusinessStructureRequest>()
+                .ForMember(dest => dest.ClienteId, opt => opt.MapFrom(src => src.ClienteId))
+                .ForMember(dest => dest.MarcaId, opt => opt.MapFrom(src => src.MarcaId ?? 0))
+                .ForMember(dest => dest.SubmarcaId, opt => opt.MapFrom(src => src.SubmarcaId))
+                .ForMember(dest => dest.ZonaId, opt => opt.MapFrom(src => src.ZonaId ?? 0));
+
+            CreateMap<ClienteEstructuraViewModel, UpdateBusinessStructureRequest>()
+                .IncludeBase<ClienteEstructuraViewModel, BusinessStructureRequest>()
+                .ForMember(dest => dest.Estatus, opt => opt.MapFrom(src => src.Estatus == 1));
+
 
             CreateMap<UnidadDeNegocio, BusinessUnitRequest>()
             .ForMember(dest => dest.Logotipo, opt => opt.MapFrom(src => src.Logotipo ?? string.Empty))


### PR DESCRIPTION
## Summary
- map new BusinessStructureRequestDto to infrastructure models
- extend BusinessStructureProfile mappings
- map ClienteEstructuraViewModel to business structure requests
- invoke BusinessStructureApiClient from ClienteController

## Testing
- `dotnet build Farmacheck/Farmacheck.sln --nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870337ff7788331a3031a6c5206dc36