### PR TITLE
Add infrastructure registration helper

### DIFF
--- a/Farmacheck.Infrastructure/DependencyInjection.cs
+++ b/Farmacheck.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Infrastructure.Services;
+
+namespace Farmacheck.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddHttpClient<IBrandApiClient, BrandApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["BrandApi:BaseUrl"]!);
+        });
+
+        services.AddHttpClient<IBusinessUnitApiClient, BusinessUnitApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["BusinessUnitApi:BaseUrl"]!);
+        });
+
+        services.AddHttpClient<ISubbrandApiClient, SubbrandApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["SubbrandApi:BaseUrl"]!);
+        });
+
+        services.AddHttpClient<ICustomersApiClient, CustomersApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["CustomersApi:BaseUrl"]!);
+        });
+
+        services.AddHttpClient<ICustomerTypesApiClient, CustomerTypesApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["CustomerTypesApi:BaseUrl"]!);
+        });
+
+        services.AddHttpClient<IZoneApiClient, ZonesApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["ZonesApi:BaseUrl"]!);
+        });
+
+        services.AddHttpClient<IBusinessStructureApiClient, BusinessStructureApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["BusinessStructureApi:BaseUrl"]!);
+        });
+
+        return services;
+    }
+}

--- a/Farmacheck/Farmacheck.csproj
+++ b/Farmacheck/Farmacheck.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Farmacheck.Application\Farmacheck.Application.csproj" />
+    <ProjectReference Include="..\Farmacheck.Infrastructure\Farmacheck.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -1,7 +1,7 @@
-using Farmacheck.Infrastructure.Services;
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Mappings;
 using Farmacheck.Helpers;
+using Farmacheck.Infrastructure;
 namespace Farmacheck
 {
     public class Program
@@ -25,40 +25,7 @@ namespace Farmacheck
                 typeof(CustomerTypeProfile),
                 typeof(ZoneProfile));
 
-            builder.Services.AddHttpClient<IBrandApiClient, BrandApiClient>(client =>
-            {
-                client.BaseAddress = new Uri(builder.Configuration["BrandApi:BaseUrl"]!);
-            });
-
-            builder.Services.AddHttpClient<IBusinessUnitApiClient, BusinessUnitApiClient>(client =>
-            {
-                client.BaseAddress = new Uri(builder.Configuration["BusinessUnitApi:BaseUrl"]!);
-            });
-
-            builder.Services.AddHttpClient<ISubbrandApiClient, SubbrandApiClient>(client =>
-            {
-                client.BaseAddress = new Uri(builder.Configuration["SubbrandApi:BaseUrl"]!);
-            });
-
-            builder.Services.AddHttpClient<ICustomersApiClient, CustomersApiClient>(client =>
-            {
-                client.BaseAddress = new Uri(builder.Configuration["CustomersApi:BaseUrl"]!);
-            });
-
-            builder.Services.AddHttpClient<ICustomerTypesApiClient, CustomerTypesApiClient>(client =>
-            {
-                client.BaseAddress = new Uri(builder.Configuration["CustomerTypesApi:BaseUrl"]!);
-            });
-
-            builder.Services.AddHttpClient<IZoneApiClient, ZonesApiClient>(client =>
-            {
-                client.BaseAddress = new Uri(builder.Configuration["ZonesApi:BaseUrl"]!);
-            });
-
-            builder.Services.AddHttpClient<IBusinessStructureApiClient, BusinessStructureApiClient>(client =>
-            {
-                client.BaseAddress = new Uri(builder.Configuration["BusinessStructureApi:BaseUrl"]!);
-            });
+            builder.Services.AddInfrastructure(builder.Configuration);
 
             var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- centralize service registrations with an `AddInfrastructure` extension method
- reference Infrastructure project from web project
- call `AddInfrastructure` from `Program.cs` for clean dependency setup

## Testing
- `dotnet build Farmacheck/Farmacheck.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68709c56477483318bd2eba31e15f9e4