### PR TITLE
Add CategoryByQuestionnaire API client

### DIFF
--- a/Farmacheck.Application/DTOs/CategoryByQuestionnaireDto.cs
+++ b/Farmacheck.Application/DTOs/CategoryByQuestionnaireDto.cs
@@ -1,0 +1,11 @@
+namespace Farmacheck.Application.DTOs
+{
+    public class CategoryByQuestionnaireDto
+    {
+        public byte Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public bool Activa { get; set; }
+        public string? NombreDelArchivoConIcono { get; set; }
+        public DateTime ModificadaEl { get; set; }
+    }
+}

--- a/Farmacheck.Application/Interfaces/ICategoryByQuestionnaireApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ICategoryByQuestionnaireApiClient.cs
@@ -1,0 +1,14 @@
+using Farmacheck.Application.Models.CategoriesByQuestionnaires;
+
+namespace Farmacheck.Application.Interfaces
+{
+    public interface ICategoryByQuestionnaireApiClient
+    {
+        Task<List<CategoryByQuestionnaireResponse>> GetCategoriesAsync();
+        Task<List<CategoryByQuestionnaireResponse>> GetCategoriesByPageAsync(int page, int items);
+        Task<CategoryByQuestionnaireResponse?> GetCategoryAsync(byte id);
+        Task<byte> CreateAsync(CategoryByQuestionnaireRequest request);
+        Task<bool> UpdateAsync(UpdateCategoryByQuestionnaireRequest request);
+        Task DeleteAsync(byte id);
+    }
+}

--- a/Farmacheck.Application/Mappings/CategoryByQuestionnaireProfile.cs
+++ b/Farmacheck.Application/Mappings/CategoryByQuestionnaireProfile.cs
@@ -1,0 +1,16 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Application.Models.CategoriesByQuestionnaires;
+
+namespace Farmacheck.Application.Mappings
+{
+    public class CategoryByQuestionnaireProfile : Profile
+    {
+        public CategoryByQuestionnaireProfile()
+        {
+            CreateMap<CategoryByQuestionnaireResponse, CategoryByQuestionnaireDto>();
+            CreateMap<CategoryByQuestionnaireDto, CategoryByQuestionnaireRequest>();
+            CreateMap<CategoryByQuestionnaireDto, UpdateCategoryByQuestionnaireRequest>();
+        }
+    }
+}

--- a/Farmacheck.Application/Models/CategoriesByQuestionnaires/CategoryByQuestionnaireRequest.cs
+++ b/Farmacheck.Application/Models/CategoriesByQuestionnaires/CategoryByQuestionnaireRequest.cs
@@ -1,0 +1,8 @@
+namespace Farmacheck.Application.Models.CategoriesByQuestionnaires
+{
+    public class CategoryByQuestionnaireRequest
+    {
+        public string Nombre { get; set; } = null!;
+        public string? NombreDelArchivoConIcono { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/CategoriesByQuestionnaires/CategoryByQuestionnaireResponse.cs
+++ b/Farmacheck.Application/Models/CategoriesByQuestionnaires/CategoryByQuestionnaireResponse.cs
@@ -1,0 +1,11 @@
+namespace Farmacheck.Application.Models.CategoriesByQuestionnaires
+{
+    public class CategoryByQuestionnaireResponse
+    {
+        public byte Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public bool Activa { get; set; }
+        public string? NombreDelArchivoConIcono { get; set; }
+        public DateTime ModificadaEl { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/CategoriesByQuestionnaires/UpdateCategoryByQuestionnaireRequest.cs
+++ b/Farmacheck.Application/Models/CategoriesByQuestionnaires/UpdateCategoryByQuestionnaireRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Farmacheck.Application.Models.CategoriesByQuestionnaires
+{
+    public class UpdateCategoryByQuestionnaireRequest : CategoryByQuestionnaireRequest
+    {
+        [Required]
+        public byte Id { get; set; }
+        public bool Activa { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/DependencyInjection.cs
+++ b/Farmacheck.Infrastructure/DependencyInjection.cs
@@ -44,6 +44,11 @@ public static class DependencyInjection
             client.BaseAddress = new Uri(configuration["BusinessStructureApi:BaseUrl"]!);
         });
 
+        services.AddHttpClient<ICategoryByQuestionnaireApiClient, CategoryByQuestionnaireApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["CategoriesByQuestionnairesApi:BaseUrl"]!);
+        });
+
         return services;
     }
 }

--- a/Farmacheck.Infrastructure/Services/CategoryByQuestionnaireApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CategoryByQuestionnaireApiClient.cs
@@ -1,0 +1,54 @@
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.CategoriesByQuestionnaires;
+using System.Net.Http.Json;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    public class CategoryByQuestionnaireApiClient : ICategoryByQuestionnaireApiClient
+    {
+        private readonly HttpClient _http;
+
+        public CategoryByQuestionnaireApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<CategoryByQuestionnaireResponse>> GetCategoriesAsync()
+        {
+            return await _http.GetFromJsonAsync<List<CategoryByQuestionnaireResponse>>("api/v1/CategoriesByQuestionnaires")
+                   ?? new List<CategoryByQuestionnaireResponse>();
+        }
+
+        public async Task<List<CategoryByQuestionnaireResponse>> GetCategoriesByPageAsync(int page, int items)
+        {
+            var url = $"api/v1/CategoriesByQuestionnaires/pages?page={page}&items={items}";
+            return await _http.GetFromJsonAsync<List<CategoryByQuestionnaireResponse>>(url)
+                   ?? new List<CategoryByQuestionnaireResponse>();
+        }
+
+        public async Task<CategoryByQuestionnaireResponse?> GetCategoryAsync(byte id)
+        {
+            return await _http.GetFromJsonAsync<CategoryByQuestionnaireResponse>($"api/v1/CategoriesByQuestionnaires/{id}");
+        }
+
+        public async Task<byte> CreateAsync(CategoryByQuestionnaireRequest request)
+        {
+            var response = await _http.PostAsJsonAsync("api/v1/CategoriesByQuestionnaires", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<byte>();
+        }
+
+        public async Task<bool> UpdateAsync(UpdateCategoryByQuestionnaireRequest request)
+        {
+            var response = await _http.PutAsJsonAsync("api/v1/CategoriesByQuestionnaires", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<bool>();
+        }
+
+        public async Task DeleteAsync(byte id)
+        {
+            var response = await _http.DeleteAsync($"api/v1/CategoriesByQuestionnaires/{id}");
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -23,7 +23,8 @@ namespace Farmacheck
                 typeof(BusinessStructureProfile),
                 typeof(CustomerProfile),
                 typeof(CustomerTypeProfile),
-                typeof(ZoneProfile));
+                typeof(ZoneProfile),
+                typeof(CategoryByQuestionnaireProfile));
 
             builder.Services.AddInfrastructure(builder.Configuration);
 

--- a/Farmacheck/appsettings.json
+++ b/Farmacheck/appsettings.json
@@ -26,5 +26,8 @@
   },
   "BusinessStructureApi": {
     "BaseUrl": "https://localhost:7205"
+  },
+  "CategoriesByQuestionnairesApi": {
+    "BaseUrl": "https://localhost:7205"
   }
 }


### PR DESCRIPTION
## Summary
- add models and DTO for CategoryByQuestionnaire
- add API client service and interface
- configure DI for new HTTP client
- register AutoMapper profile in Program
- add configuration entry for CategoryByQuestionnairesApi

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687861f6621083318a07539ee63080b7