### PR TITLE
Add status toggle to role modals

### DIFF
--- a/Farmacheck/Views/Rol/Index.cshtml
+++ b/Farmacheck/Views/Rol/Index.cshtml
@@ -43,6 +43,10 @@
                     <label>Unidad de Negocio</label>
                     <select class="form-select" id="unidadNegocio"></select>
                 </div>
+                <div class="form-check form-switch mb-3">
+                    <input class="form-check-input" type="checkbox" id="estatusCheck">
+                    <label class="form-check-label" for="estatusCheck">Habilitado</label>
+                </div>
                 <div class="mb-3">
                     <label class="form-label">Permisos</label>
                     <div id="contenedorPermisos" class="border rounded p-2" style="max-height:300px; overflow-y:auto;">
@@ -69,6 +73,7 @@
             $('#btnNuevo').click(function () {
                 limpiar();
                 $('#modalTitulo').text('Nuevo Rol');
+                $('#estatusCheck').prop('checked', true).prop('disabled', true);
                 $('#modalEntidad').modal('show');
                 cargarPermisos();
             });
@@ -79,6 +84,7 @@
                     Id: id,
                     Nombre: $('#nombre').val(),
                     UnidadDeNegocioId: $('#unidadNegocio').val(),
+                    Estatus: $('#estatusCheck').prop('checked'),
                     Permisos: []
                 };
 
@@ -162,6 +168,7 @@
                     $('#entidadId').val(u.id);
                     $('#nombre').val(u.nombre);
                     $('#unidadNegocio').val(u.unidadDeNegocioId);
+                    $('#estatusCheck').prop('checked', u.estatus).prop('disabled', false);
                     $('#modalEntidad').modal('show');
                     cargarPermisos(u.id);
                 } else {
@@ -187,6 +194,7 @@
             $('#entidadId').val('');
             $('#nombre').val('');
             $('#unidadNegocio').val(unidadId || '');
+            $('#estatusCheck').prop('checked', true).prop('disabled', true);
             $('#contenedorPermisos').empty();
         }
     </script>

--- a/Farmacheck/Views/Roles/Index.cshtml
+++ b/Farmacheck/Views/Roles/Index.cshtml
@@ -42,6 +42,10 @@
                     <label>Unidad de Negocio</label>
                     <select class="form-select" id="unidadNegocio"></select>
                 </div>
+                <div class="form-check form-switch mb-3">
+                    <input class="form-check-input" type="checkbox" id="estatusCheck">
+                    <label class="form-check-label" for="estatusCheck">Habilitado</label>
+                </div>
                 <div class="mb-3">
                     <label class="form-label">Permisos</label>
                     <div id="contenedorPermisos" class="border rounded p-2" style="max-height:300px; overflow-y:auto;">
@@ -68,6 +72,7 @@
             $('#btnNuevo').click(function () {
                 limpiar();
                 $('#modalTitulo').text('Nuevo Rol');
+                $('#estatusCheck').prop('checked', true).prop('disabled', true);
                 $('#modalEntidad').modal('show');
                 cargarPermisos();
             });
@@ -78,6 +83,7 @@
                     Id: id,
                     Nombre: $('#nombre').val(),
                     UnidadDeNegocioId: $('#unidadNegocio').val(),
+                    Estatus: $('#estatusCheck').prop('checked'),
                     Permisos: []
                 };
 
@@ -160,6 +166,7 @@
                     $('#entidadId').val(u.id);
                     $('#nombre').val(u.nombre);
                     $('#unidadNegocio').val(u.unidadDeNegocioId);
+                    $('#estatusCheck').prop('checked', u.estatus).prop('disabled', false);
                     $('#modalEntidad').modal('show');
                     cargarPermisos(u.id);
                 } else {
@@ -185,6 +192,7 @@
             $('#entidadId').val('');
             $('#nombre').val('');
             $('#unidadNegocio').val(unidadId || '');
+            $('#estatusCheck').prop('checked', true).prop('disabled', true);
             $('#contenedorPermisos').empty();
         }
     </script>


### PR DESCRIPTION
## Summary
- enable managing role status in role modals

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885caef051083319177b11e22768ea8