### PR TITLE
Add Permissions API client

### DIFF
--- a/Farmacheck.Application/DTOs/PermissionDto.cs
+++ b/Farmacheck.Application/DTOs/PermissionDto.cs
@@ -1,0 +1,11 @@
+namespace Farmacheck.Application.DTOs
+{
+    public class PermissionDto
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public string? Descripcion { get; set; }
+        public bool Estatus { get; set; }
+        public DateTime CreadoEl { get; set; }
+    }
+}

--- a/Farmacheck.Application/Interfaces/IPermissionApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IPermissionApiClient.cs
@@ -1,0 +1,14 @@
+using Farmacheck.Application.Models.Permissions;
+
+namespace Farmacheck.Application.Interfaces
+{
+    public interface IPermissionApiClient
+    {
+        Task<List<PermissionResponse>> GetPermissionsAsync();
+        Task<List<PermissionResponse>> GetPermissionsByPageAsync(int page, int items);
+        Task<PermissionResponse?> GetPermissionAsync(int id);
+        Task<int> CreateAsync(PermissionRequest request);
+        Task<bool> UpdateAsync(UpdatePermissionRequest request);
+        Task DeleteAsync(int id);
+    }
+}

--- a/Farmacheck.Application/Mappings/PermissionProfile.cs
+++ b/Farmacheck.Application/Mappings/PermissionProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Application.Models.Permissions;
+
+namespace Farmacheck.Application.Mappings
+{
+    public class PermissionProfile : Profile
+    {
+        public PermissionProfile()
+        {
+            CreateMap<PermissionResponse, PermissionDto>().ReverseMap();
+        }
+    }
+}

--- a/Farmacheck.Application/Models/Permissions/PermissionRequest.cs
+++ b/Farmacheck.Application/Models/Permissions/PermissionRequest.cs
@@ -1,0 +1,8 @@
+namespace Farmacheck.Application.Models.Permissions
+{
+    public class PermissionRequest
+    {
+        public string Nombre { get; set; } = null!;
+        public string? Descripcion { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/Permissions/PermissionResponse.cs
+++ b/Farmacheck.Application/Models/Permissions/PermissionResponse.cs
@@ -1,0 +1,11 @@
+namespace Farmacheck.Application.Models.Permissions
+{
+    public class PermissionResponse
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public string? Descripcion { get; set; }
+        public bool Estatus { get; set; }
+        public DateTime CreadoEl { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/Permissions/UpdatePermissionRequest.cs
+++ b/Farmacheck.Application/Models/Permissions/UpdatePermissionRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Farmacheck.Application.Models.Permissions
+{
+    public class UpdatePermissionRequest : PermissionRequest
+    {
+        [Required]
+        public int Id { get; set; }
+        public bool Estatus { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/DependencyInjection.cs
+++ b/Farmacheck.Infrastructure/DependencyInjection.cs
@@ -44,6 +44,11 @@ public static class DependencyInjection
             client.BaseAddress = new Uri(configuration["RolesApi:BaseUrl"]!);
         });
 
+        services.AddHttpClient<IPermissionApiClient, PermissionsApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["PermissionsApi:BaseUrl"]!);
+        });
+
         services.AddHttpClient<IBusinessStructureApiClient, BusinessStructureApiClient>(client =>
         {
             client.BaseAddress = new Uri(configuration["BusinessStructureApi:BaseUrl"]!);

--- a/Farmacheck.Infrastructure/Services/PermissionsApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/PermissionsApiClient.cs
@@ -1,0 +1,54 @@
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.Permissions;
+using System.Net.Http.Json;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    public class PermissionsApiClient : IPermissionApiClient
+    {
+        private readonly HttpClient _http;
+
+        public PermissionsApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<PermissionResponse>> GetPermissionsAsync()
+        {
+            return await _http.GetFromJsonAsync<List<PermissionResponse>>("api/v1/Permissions")
+                   ?? new List<PermissionResponse>();
+        }
+
+        public async Task<List<PermissionResponse>> GetPermissionsByPageAsync(int page, int items)
+        {
+            var url = $"api/v1/Permissions/pages?page={page}&items={items}";
+            return await _http.GetFromJsonAsync<List<PermissionResponse>>(url)
+                   ?? new List<PermissionResponse>();
+        }
+
+        public async Task<PermissionResponse?> GetPermissionAsync(int id)
+        {
+            return await _http.GetFromJsonAsync<PermissionResponse>($"api/v1/Permissions/{id}");
+        }
+
+        public async Task<int> CreateAsync(PermissionRequest request)
+        {
+            var response = await _http.PostAsJsonAsync("api/v1/Permissions", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<int>();
+        }
+
+        public async Task<bool> UpdateAsync(UpdatePermissionRequest request)
+        {
+            var response = await _http.PutAsJsonAsync("api/v1/Permissions", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<bool>();
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            var response = await _http.DeleteAsync($"api/v1/Permissions/{id}");
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -25,7 +25,8 @@ namespace Farmacheck
                 typeof(CustomerTypeProfile),
                 typeof(ZoneProfile),
                 typeof(CategoryByQuestionnaireProfile),
-                typeof(RoleProfile));
+                typeof(RoleProfile),
+                typeof(PermissionProfile));
 
             builder.Services.AddInfrastructure(builder.Configuration);
 

--- a/Farmacheck/appsettings.json
+++ b/Farmacheck/appsettings.json
@@ -32,5 +32,8 @@
   },
   "RolesApi": {
     "BaseUrl": "https://localhost:7205"
+  },
+  "PermissionsApi": {
+    "BaseUrl": "https://localhost:7205"
   }
 }


### PR DESCRIPTION
## Summary
- add Permission service models and DTO
- add client service and interface for Permissions
- register Permissions API client
- wire up Permission profile and base URL

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885d1b52cfc8331901626184b2a6897