### PR TITLE
Add HierarchyByRole API client

### DIFF
--- a/Farmacheck.Application/DTOs/HierarchyByRoleDto.cs
+++ b/Farmacheck.Application/DTOs/HierarchyByRoleDto.cs
@@ -1,0 +1,12 @@
+namespace Farmacheck.Application.DTOs
+{
+    public class HierarchyByRoleDto
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public int RolSuperiorId { get; set; }
+        public int RolSubordinadoId { get; set; }
+        public DateTime AsignadoEl { get; set; }
+        public bool Estatus { get; set; }
+    }
+}

--- a/Farmacheck.Application/Interfaces/IHierarchyByRoleApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IHierarchyByRoleApiClient.cs
@@ -1,0 +1,14 @@
+using Farmacheck.Application.Models.HierarchyByRoles;
+
+namespace Farmacheck.Application.Interfaces
+{
+    public interface IHierarchyByRoleApiClient
+    {
+        Task<List<HierarchyByRoleResponse>> GetAllAsync();
+        Task<List<HierarchyByRoleResponse>> GetByPageAsync(int page, int items);
+        Task<HierarchyByRoleResponse?> GetAsync(int id);
+        Task<int> CreateAsync(HierarchyByRoleRequest request);
+        Task<bool> UpdateAsync(UpdateHierarchyByRoleRequest request);
+        Task DeleteAsync(int id);
+    }
+}

--- a/Farmacheck.Application/Mappings/HierarchyByRoleProfile.cs
+++ b/Farmacheck.Application/Mappings/HierarchyByRoleProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Application.Models.HierarchyByRoles;
+
+namespace Farmacheck.Application.Mappings
+{
+    public class HierarchyByRoleProfile : Profile
+    {
+        public HierarchyByRoleProfile()
+        {
+            CreateMap<HierarchyByRoleResponse, HierarchyByRoleDto>().ReverseMap();
+        }
+    }
+}

--- a/Farmacheck.Application/Models/HierarchyByRoles/HierarchyByRoleRequest.cs
+++ b/Farmacheck.Application/Models/HierarchyByRoles/HierarchyByRoleRequest.cs
@@ -1,0 +1,9 @@
+namespace Farmacheck.Application.Models.HierarchyByRoles
+{
+    public class HierarchyByRoleRequest
+    {
+        public string Nombre { get; set; } = null!;
+        public int RolSuperiorId { get; set; }
+        public int RolSubordinadoId { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/HierarchyByRoles/HierarchyByRoleResponse.cs
+++ b/Farmacheck.Application/Models/HierarchyByRoles/HierarchyByRoleResponse.cs
@@ -1,0 +1,12 @@
+namespace Farmacheck.Application.Models.HierarchyByRoles
+{
+    public class HierarchyByRoleResponse
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public int RolSuperiorId { get; set; }
+        public int RolSubordinadoId { get; set; }
+        public DateTime AsignadoEl { get; set; }
+        public bool Estatus { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/HierarchyByRoles/UpdateHierarchyByRoleRequest.cs
+++ b/Farmacheck.Application/Models/HierarchyByRoles/UpdateHierarchyByRoleRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Farmacheck.Application.Models.HierarchyByRoles
+{
+    public class UpdateHierarchyByRoleRequest : HierarchyByRoleRequest
+    {
+        [Required]
+        public int Id { get; set; }
+        public bool? Estatus { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/DependencyInjection.cs
+++ b/Farmacheck.Infrastructure/DependencyInjection.cs
@@ -59,6 +59,11 @@ public static class DependencyInjection
             client.BaseAddress = new Uri(configuration["CategoriesByQuestionnairesApi:BaseUrl"]!);
         });
 
+        services.AddHttpClient<IHierarchyByRoleApiClient, HierarchyByRolesApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["HierarchyByRolesApi:BaseUrl"]!);
+        });
+
         return services;
     }
 }

--- a/Farmacheck.Infrastructure/Services/HierarchyByRolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/HierarchyByRolesApiClient.cs
@@ -1,0 +1,54 @@
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.HierarchyByRoles;
+using System.Net.Http.Json;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    public class HierarchyByRolesApiClient : IHierarchyByRoleApiClient
+    {
+        private readonly HttpClient _http;
+
+        public HierarchyByRolesApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<HierarchyByRoleResponse>> GetAllAsync()
+        {
+            return await _http.GetFromJsonAsync<List<HierarchyByRoleResponse>>("api/v1/HierarchyByRole")
+                   ?? new List<HierarchyByRoleResponse>();
+        }
+
+        public async Task<List<HierarchyByRoleResponse>> GetByPageAsync(int page, int items)
+        {
+            var url = $"api/v1/HierarchyByRole/pages?page={page}&items={items}";
+            return await _http.GetFromJsonAsync<List<HierarchyByRoleResponse>>(url)
+                   ?? new List<HierarchyByRoleResponse>();
+        }
+
+        public async Task<HierarchyByRoleResponse?> GetAsync(int id)
+        {
+            return await _http.GetFromJsonAsync<HierarchyByRoleResponse>($"api/v1/HierarchyByRole/{id}");
+        }
+
+        public async Task<int> CreateAsync(HierarchyByRoleRequest request)
+        {
+            var response = await _http.PostAsJsonAsync("api/v1/HierarchyByRole", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<int>();
+        }
+
+        public async Task<bool> UpdateAsync(UpdateHierarchyByRoleRequest request)
+        {
+            var response = await _http.PutAsJsonAsync("api/v1/HierarchyByRole", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<bool>();
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            var response = await _http.DeleteAsync($"api/v1/HierarchyByRole/{id}");
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -26,7 +26,8 @@ namespace Farmacheck
                 typeof(ZoneProfile),
                 typeof(CategoryByQuestionnaireProfile),
                 typeof(RoleProfile),
-                typeof(PermissionProfile));
+                typeof(PermissionProfile),
+                typeof(HierarchyByRoleProfile));
 
             builder.Services.AddInfrastructure(builder.Configuration);
 


### PR DESCRIPTION
## Summary
- implement HierarchyByRole models, DTO and AutoMapper profile
- create API client and interface to consume HierarchyByRole endpoints
- register HierarchyByRole client in DI and include new profile

## Testing
- `dotnet build Farmacheck/Farmacheck.sln -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68869b5cb29883319587e01c27d1c826