### PR TITLE
Implement role hierarchy management

### DIFF
--- a/Farmacheck/Controllers/JerarquiaController.cs
+++ b/Farmacheck/Controllers/JerarquiaController.cs
@@ -1,0 +1,108 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.HierarchyByRoles;
+using Farmacheck.Application.Models.Roles;
+using Farmacheck.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Farmacheck.Controllers
+{
+    public class JerarquiaController : Controller
+    {
+        private readonly IHierarchyByRoleApiClient _apiClient;
+        private readonly IRoleApiClient _roleApi;
+        private readonly IMapper _mapper;
+
+        public JerarquiaController(IHierarchyByRoleApiClient apiClient,
+                                   IRoleApiClient roleApi,
+                                   IMapper mapper)
+        {
+            _apiClient = apiClient;
+            _roleApi = roleApi;
+            _mapper = mapper;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var apiData = await _apiClient.GetAllAsync();
+            var dtos = _mapper.Map<List<HierarchyByRoleDto>>(apiData);
+            var models = _mapper.Map<List<JerarquiaViewModel>>(dtos);
+
+            await CompletarNombresRoles(models);
+
+            return View(models);
+        }
+
+        [HttpGet]
+        public async Task<JsonResult> Listar()
+        {
+            var apiData = await _apiClient.GetAllAsync();
+            var dtos = _mapper.Map<List<HierarchyByRoleDto>>(apiData);
+            var models = _mapper.Map<List<JerarquiaViewModel>>(dtos);
+
+            await CompletarNombresRoles(models);
+
+            return Json(new { success = true, data = models });
+        }
+
+        [HttpGet]
+        public async Task<JsonResult> Obtener(int id)
+        {
+            var entidad = await _apiClient.GetAsync(id);
+            if (entidad == null)
+                return Json(new { success = false, error = "No encontrado" });
+
+            var dto = _mapper.Map<HierarchyByRoleDto>(entidad);
+            var model = _mapper.Map<JerarquiaViewModel>(dto);
+            await CompletarNombresRoles(new List<JerarquiaViewModel> { model });
+
+            return Json(new { success = true, data = model });
+        }
+
+        [HttpPost]
+        public async Task<JsonResult> Guardar([FromBody] List<JerarquiaViewModel> modelos)
+        {
+            try
+            {
+                if (modelos == null || modelos.Count == 0)
+                    return Json(new { success = false, error = "Sin datos" });
+
+                var existentes = await _apiClient.GetAllAsync();
+                foreach (var m in modelos)
+                {
+                    if (existentes.Any(e => e.RolSuperiorId == m.RolSuperiorId && e.RolSubordinadoId == m.RolSubordinadoId))
+                        continue;
+
+                    var request = _mapper.Map<HierarchyByRoleRequest>(m);
+                    await _apiClient.CreateAsync(request);
+                }
+
+                return Json(new { success = true });
+            }
+            catch (Exception ex)
+            {
+                return Json(new { success = false, error = "Ocurrió un error inesperado: " + ex.Message });
+            }
+        }
+
+        [HttpPost]
+        public async Task<JsonResult> Eliminar(int id)
+        {
+            await _apiClient.DeleteAsync(id);
+            return Json(new { success = true });
+        }
+
+        private async Task CompletarNombresRoles(IEnumerable<JerarquiaViewModel> modelos)
+        {
+            var roles = await _roleApi.GetRolesAsync();
+            foreach (var m in modelos)
+            {
+                var sup = roles.FirstOrDefault(r => r.Id == m.RolSuperiorId);
+                var sub = roles.FirstOrDefault(r => r.Id == m.RolSubordinadoId);
+                m.RolSuperiorNombre = sup?.Nombre;
+                m.RolSubordinadoNombre = sub?.Nombre;
+            }
+        }
+    }
+}

--- a/Farmacheck/Helpers/WebMappingProfile.cs
+++ b/Farmacheck/Helpers/WebMappingProfile.cs
@@ -117,6 +117,10 @@ namespace Farmacheck.Helpers
             CreateMap<CategoriaCuestionarioViewModel, CategoryByQuestionnaireRequest>();
 
             CreateMap<CategoriaCuestionarioViewModel, UpdateCategoryByQuestionnaireRequest>();
+
+            CreateMap<HierarchyByRoleDto, JerarquiaViewModel>().ReverseMap();
+            CreateMap<JerarquiaViewModel, HierarchyByRoleRequest>();
+            CreateMap<JerarquiaViewModel, UpdateHierarchyByRoleRequest>();
         }
     }
 }

--- a/Farmacheck/Models/JerarquiaViewModel.cs
+++ b/Farmacheck/Models/JerarquiaViewModel.cs
@@ -1,6 +1,14 @@
-﻿namespace Farmacheck.Models
+namespace Farmacheck.Models
 {
     public class JerarquiaViewModel
     {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = string.Empty;
+        public int RolSuperiorId { get; set; }
+        public int RolSubordinadoId { get; set; }
+        public string? RolSuperiorNombre { get; set; }
+        public string? RolSubordinadoNombre { get; set; }
+        public DateTime AsignadoEl { get; set; }
+        public bool Estatus { get; set; }
     }
 }

--- a/Farmacheck/Views/Jerarquia/Index.cshtml
+++ b/Farmacheck/Views/Jerarquia/Index.cshtml
@@ -1,0 +1,215 @@
+@model List<Farmacheck.Models.JerarquiaViewModel>
+@{
+    ViewData["Title"] = "Jerarquía";
+}
+
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="text-dark">Jerarquía de Roles</h4>
+        <button id="btnNuevo" class="btn" style="background-color:#00ab8e; color:white;">
+            <i class="bi bi-plus-circle"></i> Nueva relación
+        </button>
+    </div>
+    <table class="table table-bordered custom-table" id="tablaDatos">
+        <thead>
+            <tr>
+                <th style="width:15%;">Id</th>
+                <th style="width:35%;">Rol Superior</th>
+                <th style="width:35%;">Rol Subordinado</th>
+                <th style="width:15%;" class="text-center">Acciones</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+<div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header bg-primary_form text-white">
+                <h5 class="modal-title" id="modalTitulo">Nueva relación</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row g-2 align-items-end">
+                    <div class="col-md-5">
+                        <label>Rol Superior</label>
+                        <select class="form-select" id="rolSuperior"></select>
+                    </div>
+                    <div class="col-md-5">
+                        <label>Rol Subordinado</label>
+                        <select class="form-select" id="rolSubordinado"></select>
+                    </div>
+                    <div class="col-md-2">
+                        <button type="button" id="btnAgregar" class="btn btn-outline-primary w-100">Agregar</button>
+                    </div>
+                </div>
+                <table class="table table-bordered mt-3" id="tablaTemp">
+                    <thead>
+                        <tr>
+                            <th>Rol Superior</th>
+                            <th>Rol Subordinado</th>
+                            <th style="width:50px"></th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button id="btnGuardar" class="btn btn-primary">Guardar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        $(document).ready(function () {
+            cargar();
+            cargarRoles();
+
+            $('#btnNuevo').click(function () {
+                limpiar();
+                $('#modalEntidad').modal('show');
+            });
+
+            $('#rolSuperior').change(function () {
+                cargarRolesSubordinado($(this).val());
+            });
+
+            $('#btnAgregar').click(function () {
+                const supId = $('#rolSuperior').val();
+                const subId = $('#rolSubordinado').val();
+                if (!supId || !subId) return;
+
+                let repetido = false;
+                $('#tablaTemp tbody tr').each(function () {
+                    if ($(this).data('sup') == supId && $(this).data('sub') == subId) {
+                        repetido = true;
+                        return false;
+                    }
+                });
+                if (repetido) {
+                    showAlert('La relación ya fue agregada.', 'warning');
+                    return;
+                }
+
+                const supText = $('#rolSuperior option:selected').text();
+                const subText = $('#rolSubordinado option:selected').text();
+                $('#tablaTemp tbody').append(`<tr data-sup="${supId}" data-sub="${subId}">
+                        <td>${supText}</td>
+                        <td>${subText}</td>
+                        <td class="text-center">
+                            <button class="btn btn-sm btn-danger" onclick="$(this).closest('tr').remove()"><i class="bi bi-trash"></i></button>
+                        </td>
+                    </tr>`);
+            });
+
+            $('#btnGuardar').click(function () {
+                const datos = [];
+                $('#tablaTemp tbody tr').each(function () {
+                    datos.push({
+                        RolSuperiorId: $(this).data('sup'),
+                        RolSubordinadoId: $(this).data('sub')
+                    });
+                });
+
+                if (datos.length === 0) {
+                    showAlert('Agregue al menos una relación.', 'warning');
+                    return;
+                }
+
+                $.ajax({
+                    url: '@Url.Action("Guardar", "Jerarquia")',
+                    method: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify(datos),
+                    success: function (r) {
+                        if (r.success) {
+                            $('#modalEntidad').modal('hide');
+                            showAlert('Relaciones guardadas', 'success');
+                            cargar();
+                        } else {
+                            showAlert(r.error || 'Error al guardar', 'error');
+                        }
+                    }
+                });
+            });
+        });
+
+        function cargar() {
+            $.get('@Url.Action("Listar", "Jerarquia")', function (r) {
+                if (r.success) {
+                    const tabla = $('#tablaDatos');
+                    if ($.fn.DataTable.isDataTable(tabla)) {
+                        tabla.DataTable().destroy();
+                    }
+
+                    const tbody = tabla.find('tbody');
+                    tbody.empty();
+                    r.data.forEach(u => {
+                        tbody.append(`<tr>
+                            <td>${u.id}</td>
+                            <td>${u.rolSuperiorNombre}</td>
+                            <td>${u.rolSubordinadoNombre}</td>
+                            <td class="text-center">
+                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
+                            </td>
+                        </tr>`);
+                    });
+
+                    tabla.DataTable({
+                        pageLength: 5,
+                        lengthMenu: [5, 10, 25, 50, 100],
+                        language: {
+                            url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
+                        }
+                    });
+                }
+            });
+        }
+
+        function cargarRoles() {
+            $.get('@Url.Action("Listar", "Rol")', function (r) {
+                const select = $('#rolSuperior');
+                select.empty();
+                r.data.forEach(u => {
+                    select.append(`<option value="${u.id}">${u.nombre}</option>`);
+                });
+                cargarRolesSubordinado(select.val());
+            });
+        }
+
+        function cargarRolesSubordinado(supId) {
+            $.get('@Url.Action("Listar", "Rol")', function (r) {
+                const select = $('#rolSubordinado');
+                select.empty();
+                r.data.forEach(u => {
+                    if (u.id != supId) {
+                        select.append(`<option value="${u.id}">${u.nombre}</option>`);
+                    }
+                });
+            });
+        }
+
+        function eliminar(id) {
+            confirmAction('¿Deseas eliminar esta relación?').then(function (ok) {
+                if (!ok) return;
+                $.post('@Url.Action("Eliminar", "Jerarquia")', { id }, function (r) {
+                    if (r.success) {
+                        cargar();
+                    } else {
+                        showAlert(r.error || 'Error al eliminar', 'error');
+                    }
+                });
+            });
+        }
+
+        function limpiar() {
+            $('#tablaTemp tbody').empty();
+            $('#rolSuperior').val('');
+            $('#rolSubordinado').empty();
+        }
+    </script>
+}


### PR DESCRIPTION
## Summary
- define `JerarquiaViewModel`
- map hierarchy DTOs to the new view model in `WebMappingProfile`
- add `JerarquiaController` to manage role hierarchies
- create `Jerarquia/Index` view with modal UI for adding relationships

## Testing
- `dotnet build Farmacheck/Farmacheck.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a927383083318194c590f22b89cb