### PR TITLE
Refactor Jerarquia controller hierarchy retrieval

### DIFF
--- a/Farmacheck/Controllers/JerarquiaController.cs
+++ b/Farmacheck/Controllers/JerarquiaController.cs
@@ -25,24 +25,14 @@ namespace Farmacheck.Controllers
 
         public async Task<IActionResult> Index()
         {
-            var apiData = await _apiClient.GetAllAsync();
-            var dtos = _mapper.Map<List<HierarchyByRoleDto>>(apiData);
-            var models = _mapper.Map<List<JerarquiaViewModel>>(dtos);
-
-            await CompletarNombresRoles(models);
-
+            var models = await ObtenerJerarquiasAsync();
             return View(models);
         }
 
         [HttpGet]
         public async Task<JsonResult> Listar()
         {
-            var apiData = await _apiClient.GetAllAsync();
-            var dtos = _mapper.Map<List<HierarchyByRoleDto>>(apiData);
-            var models = _mapper.Map<List<JerarquiaViewModel>>(dtos);
-
-            await CompletarNombresRoles(models);
-
+            var models = await ObtenerJerarquiasAsync();
             return Json(new { success = true, data = models });
         }
 
@@ -91,6 +81,17 @@ namespace Farmacheck.Controllers
         {
             await _apiClient.DeleteAsync(id);
             return Json(new { success = true });
+        }
+
+        private async Task<List<JerarquiaViewModel>> ObtenerJerarquiasAsync()
+        {
+            var apiData = await _apiClient.GetAllAsync();
+            var dtos = _mapper.Map<List<HierarchyByRoleDto>>(apiData);
+            var models = _mapper.Map<List<JerarquiaViewModel>>(dtos);
+
+            await CompletarNombresRoles(models);
+
+            return models;
         }
 
         private async Task CompletarNombresRoles(IEnumerable<JerarquiaViewModel> modelos)


### PR DESCRIPTION
## Summary
- refactor Index and Listar to use a helper that calls `GetAllAsync`
- centralize hierarchy retrieval logic with `ObtenerJerarquiasAsync`

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886df396b988331b8a978b5ba916a98