### PR TITLE
Add user API integration

### DIFF
--- a/Farmacheck.Application/DTOs/UserDto.cs
+++ b/Farmacheck.Application/DTOs/UserDto.cs
@@ -1,0 +1,15 @@
+namespace Farmacheck.Application.DTOs
+{
+    public class UserDto
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public string ApellidoPaterno { get; set; } = null!;
+        public string? ApellidoMaterno { get; set; }
+        public string Email { get; set; } = null!;
+        public long? NumeroDeTelefono { get; set; }
+        public bool Estatus { get; set; }
+        public DateTime CreadoEl { get; set; }
+        public DateTime ActualizadoEl { get; set; }
+    }
+}

--- a/Farmacheck.Application/Interfaces/IUserApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IUserApiClient.cs
@@ -1,0 +1,14 @@
+using Farmacheck.Application.Models.Users;
+
+namespace Farmacheck.Application.Interfaces
+{
+    public interface IUserApiClient
+    {
+        Task<List<UserResponse>> GetUsersAsync();
+        Task<List<UserResponse>> GetUsersByPageAsync(int page, int items);
+        Task<UserResponse?> GetUserAsync(int id);
+        Task<int> CreateAsync(UserRequest request);
+        Task<bool> UpdateAsync(UpdateUserRequest request);
+        Task DeleteAsync(int id);
+    }
+}

--- a/Farmacheck.Application/Mappings/UserProfile.cs
+++ b/Farmacheck.Application/Mappings/UserProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Application.Models.Users;
+
+namespace Farmacheck.Application.Mappings
+{
+    public class UserProfile : Profile
+    {
+        public UserProfile()
+        {
+            CreateMap<UserResponse, UserDto>().ReverseMap();
+        }
+    }
+}

--- a/Farmacheck.Application/Models/Users/UpdateUserRequest.cs
+++ b/Farmacheck.Application/Models/Users/UpdateUserRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Farmacheck.Application.Models.Users
+{
+    public class UpdateUserRequest : UserRequest
+    {
+        [Required]
+        public int Id { get; set; }
+        public bool Estatus { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/Users/UserRequest.cs
+++ b/Farmacheck.Application/Models/Users/UserRequest.cs
@@ -1,0 +1,11 @@
+namespace Farmacheck.Application.Models.Users
+{
+    public class UserRequest
+    {
+        public string Nombre { get; set; }
+        public string ApellidoPaterno { get; set; }
+        public string? ApellidoMaterno { get; set; }
+        public string Email { get; set; }
+        public long? NumeroDeTelefono { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/Users/UserResponse.cs
+++ b/Farmacheck.Application/Models/Users/UserResponse.cs
@@ -1,0 +1,15 @@
+namespace Farmacheck.Application.Models.Users
+{
+    public class UserResponse
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public string ApellidoPaterno { get; set; } = null!;
+        public string? ApellidoMaterno { get; set; }
+        public string Email { get; set; } = null!;
+        public long? NumeroDeTelefono { get; set; }
+        public bool Estatus { get; set; }
+        public DateTime CreadoEl { get; set; }
+        public DateTime ActualizadoEl { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/DependencyInjection.cs
+++ b/Farmacheck.Infrastructure/DependencyInjection.cs
@@ -64,6 +64,11 @@ public static class DependencyInjection
             client.BaseAddress = new Uri(configuration["HierarchyByRolesApi:BaseUrl"]!);
         });
 
+        services.AddHttpClient<IUserApiClient, UsersApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["UsersApi:BaseUrl"]!);
+        });
+
         return services;
     }
 }

--- a/Farmacheck.Infrastructure/Services/UsersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/UsersApiClient.cs
@@ -1,0 +1,54 @@
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.Users;
+using System.Net.Http.Json;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    public class UsersApiClient : IUserApiClient
+    {
+        private readonly HttpClient _http;
+
+        public UsersApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<UserResponse>> GetUsersAsync()
+        {
+            return await _http.GetFromJsonAsync<List<UserResponse>>("api/v1/Users")
+                   ?? new List<UserResponse>();
+        }
+
+        public async Task<List<UserResponse>> GetUsersByPageAsync(int page, int items)
+        {
+            var url = $"api/v1/Users/pages?page={page}&items={items}";
+            return await _http.GetFromJsonAsync<List<UserResponse>>(url)
+                   ?? new List<UserResponse>();
+        }
+
+        public async Task<UserResponse?> GetUserAsync(int id)
+        {
+            return await _http.GetFromJsonAsync<UserResponse>($"api/v1/Users/{id}");
+        }
+
+        public async Task<int> CreateAsync(UserRequest request)
+        {
+            var response = await _http.PostAsJsonAsync("api/v1/Users", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<int>();
+        }
+
+        public async Task<bool> UpdateAsync(UpdateUserRequest request)
+        {
+            var response = await _http.PutAsJsonAsync("api/v1/Users", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<bool>();
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            var response = await _http.DeleteAsync($"api/v1/Users/{id}");
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -27,7 +27,8 @@ namespace Farmacheck
                 typeof(CategoryByQuestionnaireProfile),
                 typeof(RoleProfile),
                 typeof(PermissionProfile),
-                typeof(HierarchyByRoleProfile));
+                typeof(HierarchyByRoleProfile),
+                typeof(UserProfile));
 
             builder.Services.AddInfrastructure(builder.Configuration);
 


### PR DESCRIPTION
## Summary
- introduce `IUserApiClient` and implementation `UsersApiClient`
- define User models and DTO
- map UserResponse to UserDto
- register user client in dependency injection
- expose mapping profile in web startup

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887084920608331ae1d67d692a789a1