### PR TITLE
Add CRUD UI for Usuario

### DIFF
--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -1,0 +1,93 @@
+using Farmacheck.Models;
+using Microsoft.AspNetCore.Mvc;
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.Users;
+using AutoMapper;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System;
+using Farmacheck.Application.DTOs;
+
+namespace Farmacheck.Controllers
+{
+    public class UsuarioController : Controller
+    {
+        private readonly IUserApiClient _apiClient;
+        private readonly IMapper _mapper;
+
+        public UsuarioController(IUserApiClient apiClient, IMapper mapper)
+        {
+            _apiClient = apiClient;
+            _mapper = mapper;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var apiData = await _apiClient.GetUsersAsync();
+            var dtos = _mapper.Map<List<UserDto>>(apiData);
+            var usuarios = _mapper.Map<List<UsuarioViewModel>>(dtos);
+
+            return View(usuarios);
+        }
+
+        [HttpGet]
+        public async Task<JsonResult> Listar()
+        {
+            var apiData = await _apiClient.GetUsersAsync();
+            var dtos = _mapper.Map<List<UserDto>>(apiData);
+            var usuarios = _mapper.Map<List<UsuarioViewModel>>(dtos);
+
+            return Json(new { success = true, data = usuarios });
+        }
+
+        [HttpGet]
+        public async Task<JsonResult> Obtener(int id)
+        {
+            var entidad = await _apiClient.GetUserAsync(id);
+            if (entidad == null)
+                return Json(new { success = false, error = "No encontrado" });
+
+            var dto = _mapper.Map<UserDto>(entidad);
+            var model = _mapper.Map<UsuarioViewModel>(dto);
+            return Json(new { success = true, data = model });
+        }
+
+        [HttpPost]
+        public async Task<JsonResult> Guardar([FromBody] UsuarioViewModel model)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(model.Nombre))
+                    return Json(new { success = false, error = "El nombre es obligatorio." });
+
+                var request = _mapper.Map<UserRequest>(model);
+
+                if (model.Id == 0)
+                {
+                    var id = await _apiClient.CreateAsync(request);
+                    return Json(new { success = true, id });
+                }
+                else
+                {
+                    var updateRequest = _mapper.Map<UpdateUserRequest>(model);
+                    var updated = await _apiClient.UpdateAsync(updateRequest);
+                    if (updated)
+                        return Json(new { success = true, id = model.Id });
+
+                    return Json(new { success = false, error = "No se pudo actualizar" });
+                }
+            }
+            catch (Exception ex)
+            {
+                return Json(new { success = false, error = "Ocurrió un error inesperado: " + ex.Message });
+            }
+        }
+
+        [HttpPost]
+        public async Task<JsonResult> Eliminar(int id)
+        {
+            await _apiClient.DeleteAsync(id);
+            return Json(new { success = true });
+        }
+    }
+}

--- a/Farmacheck/Helpers/WebMappingProfile.cs
+++ b/Farmacheck/Helpers/WebMappingProfile.cs
@@ -11,6 +11,7 @@ using Farmacheck.Application.Models.Zones;
 using Farmacheck.Application.Models.CategoriesByQuestionnaires;
 using Farmacheck.Application.Models.Roles;
 using Farmacheck.Application.Models.HierarchyByRoles;
+using Farmacheck.Application.Models.Users;
 
 namespace Farmacheck.Helpers
 {
@@ -122,6 +123,10 @@ namespace Farmacheck.Helpers
             CreateMap<HierarchyByRoleDto, JerarquiaViewModel>().ReverseMap();
             CreateMap<JerarquiaViewModel, HierarchyByRoleRequest>();
             CreateMap<JerarquiaViewModel, UpdateHierarchyByRoleRequest>();
+
+            CreateMap<UserDto, UsuarioViewModel>().ReverseMap();
+            CreateMap<UsuarioViewModel, UserRequest>();
+            CreateMap<UsuarioViewModel, UpdateUserRequest>();
         }
     }
 }

--- a/Farmacheck/Models/UsuarioViewModel.cs
+++ b/Farmacheck/Models/UsuarioViewModel.cs
@@ -1,0 +1,15 @@
+namespace Farmacheck.Models
+{
+    public class UsuarioViewModel
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = null!;
+        public string ApellidoPaterno { get; set; } = null!;
+        public string? ApellidoMaterno { get; set; }
+        public string Email { get; set; } = null!;
+        public long? NumeroDeTelefono { get; set; }
+        public bool Estatus { get; set; }
+        public DateTime CreadoEl { get; set; }
+        public DateTime ActualizadoEl { get; set; }
+    }
+}

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -1,0 +1,194 @@
+@model List<Farmacheck.Models.UsuarioViewModel>
+@{
+    ViewData["Title"] = "Usuarios";
+}
+
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="text-dark">Usuarios</h4>
+        <button id="btnNuevo" class="btn" style="background-color:#00ab8e; color:white;">
+            <i class="bi bi-plus-circle"></i> Nuevo usuario
+        </button>
+    </div>
+    <table class="table table-bordered custom-table" id="tablaDatos">
+        <thead>
+            <tr>
+                <th style="width:10%;">Id</th>
+                <th style="width:25%;">Nombre</th>
+                <th style="width:25%;">Email</th>
+                <th style="width:20%;">Teléfono</th>
+                <th style="width:10%;">Estatus</th>
+                <th style="width:10%;" class="text-center">Acciones</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+<div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header bg-primary_form text-white">
+                <h5 class="modal-title" id="modalTitulo">Nuevo usuario</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="entidadId" />
+                <div class="mb-2">
+                    <label>Nombre</label>
+                    <input type="text" class="form-control" id="nombre" placeholder="Nombre" />
+                </div>
+                <div class="mb-2">
+                    <label>Apellido paterno</label>
+                    <input type="text" class="form-control" id="apellidoPaterno" placeholder="Apellido paterno" />
+                </div>
+                <div class="mb-2">
+                    <label>Apellido materno</label>
+                    <input type="text" class="form-control" id="apellidoMaterno" placeholder="Apellido materno" />
+                </div>
+                <div class="mb-2">
+                    <label>Email</label>
+                    <input type="email" class="form-control" id="email" placeholder="correo@dominio.com" />
+                </div>
+                <div class="mb-2">
+                    <label>Número de teléfono</label>
+                    <input type="text" class="form-control" id="telefono" placeholder="Teléfono" />
+                </div>
+                <div class="mb-2">
+                    <label>Estatus</label>
+                    <select class="form-select" id="estatus">
+                        <option value="true">Activo</option>
+                        <option value="false">Inactivo</option>
+                    </select>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button id="btnGuardar" class="btn btn-primary">Guardar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        $(document).ready(function () {
+            cargar();
+
+            $('#btnNuevo').click(function () {
+                limpiar();
+                $('#modalTitulo').text('Nuevo usuario');
+                $('#modalEntidad').modal('show');
+            });
+
+            $('#btnGuardar').click(function () {
+                const id = $('#entidadId').val() || 0;
+                const datos = {
+                    Id: id,
+                    Nombre: $('#nombre').val(),
+                    ApellidoPaterno: $('#apellidoPaterno').val(),
+                    ApellidoMaterno: $('#apellidoMaterno').val(),
+                    Email: $('#email').val(),
+                    NumeroDeTelefono: $('#telefono').val(),
+                    Estatus: $('#estatus').val() === 'true'
+                };
+
+                $.ajax({
+                    url: '@Url.Action("Guardar", "Usuario")',
+                    method: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify(datos),
+                    success: function (r) {
+                        if (r.success) {
+                            $('#modalEntidad').modal('hide');
+                            const mensaje = parseInt(id) === 0
+                                ? 'Usuario registrado correctamente'
+                                : 'Usuario actualizado correctamente';
+                            showAlert(mensaje, 'success');
+                            cargar();
+                        } else {
+                            showAlert(r.error || 'Error al guardar', 'error');
+                        }
+                    }
+                });
+            });
+        });
+
+        function cargar() {
+            $.get('@Url.Action("Listar", "Usuario")', function (r) {
+                if (r.success) {
+                    const tabla = $('#tablaDatos');
+                    if ($.fn.DataTable.isDataTable(tabla)) {
+                        tabla.DataTable().destroy();
+                    }
+
+                    const tbody = tabla.find('tbody');
+                    tbody.empty();
+                    r.data.forEach(u => {
+                        tbody.append(`<tr>
+                            <td>${u.id}</td>
+                            <td>${u.nombre} ${u.apellidoPaterno}</td>
+                            <td>${u.email}</td>
+                            <td>${u.numeroDeTelefono ?? ''}</td>
+                            <td>${u.estatus ? 'Activo' : 'Inactivo'}</td>
+                            <td class="text-center">
+                                <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
+                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
+                            </td>
+                        </tr>`);
+                    });
+
+                    tabla.DataTable({
+                        pageLength: 5,
+                        lengthMenu: [5, 10, 25, 50, 100],
+                        language: {
+                            url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
+                        }
+                    });
+                }
+            });
+        }
+
+        function editar(id) {
+            $.get('@Url.Action("Obtener", "Usuario")', { id }, function (r) {
+                if (r.success) {
+                    const u = r.data;
+                    $('#modalTitulo').text('Editar usuario');
+                    $('#entidadId').val(u.id);
+                    $('#nombre').val(u.nombre);
+                    $('#apellidoPaterno').val(u.apellidoPaterno);
+                    $('#apellidoMaterno').val(u.apellidoMaterno);
+                    $('#email').val(u.email);
+                    $('#telefono').val(u.numeroDeTelefono);
+                    $('#estatus').val(u.estatus ? 'true' : 'false');
+                    $('#modalEntidad').modal('show');
+                } else {
+                    showAlert(r.error || 'No se pudo cargar', 'error');
+                }
+            });
+        }
+
+        function eliminar(id) {
+            confirmAction('¿Deseas eliminar este usuario?').then(function (ok) {
+                if (!ok) return;
+                $.post('@Url.Action("Eliminar", "Usuario")', { id }, function (r) {
+                    if (r.success) {
+                        cargar();
+                    } else {
+                        showAlert(r.error || 'Error al eliminar', 'error');
+                    }
+                });
+            });
+        }
+
+        function limpiar() {
+            $('#entidadId').val('');
+            $('#nombre').val('');
+            $('#apellidoPaterno').val('');
+            $('#apellidoMaterno').val('');
+            $('#email').val('');
+            $('#telefono').val('');
+            $('#estatus').val('true');
+        }
+    </script>
+}


### PR DESCRIPTION
## Summary
- implement `UsuarioViewModel`
- map user DTOs to the new view model
- add `UsuarioController` for CRUD actions via `IUserApiClient`
- create `Usuario/Index` view to manage users

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68870afa799c8331ab1d4eb07b4f067b