### PR TITLE
Fix business unit dropdown in Manage Roles modal

### DIFF
--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -368,7 +368,9 @@
         function clearSelect(select, placeholder) {
             select.empty();
             select.append(`<option value="0">-- Selecciona ${placeholder} --</option>`);
-            select.selectpicker('refresh');
+            if (select.hasClass('selectpicker')) {
+                select.selectpicker('refresh');
+            }
         }
 
         function limpiarGestionRoles() {
@@ -388,7 +390,9 @@
                 const select = $('#selectUnidadNegocio');
                 clearSelect(select, 'unidad de negocio');
                 r.data.forEach(u => select.append(`<option value="${u.id}">${u.nombre}</option>`));
-                select.selectpicker('refresh');
+                if (select.hasClass('selectpicker')) {
+                    select.selectpicker('refresh');
+                }
             });
         }
 


### PR DESCRIPTION
## Summary
- ensure `clearSelect` only refreshes bootstrap-select on applicable elements
- guard bootstrap-select usage when loading business units

## Testing
- `dotnet build Farmacheck/Farmacheck.sln -c Release` *(fails: command not found)*
- `apt-get update` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6889aabc0204833190b91f82702729ac