### PR TITLE
Add brand lookup for user roles

### DIFF
--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -13,11 +13,13 @@ namespace Farmacheck.Controllers
     public class UsuarioController : Controller
     {
         private readonly IUserApiClient _apiClient;
+        private readonly IBrandApiClient _brandApi;
         private readonly IMapper _mapper;
 
-        public UsuarioController(IUserApiClient apiClient, IMapper mapper)
+        public UsuarioController(IUserApiClient apiClient, IBrandApiClient brandApi, IMapper mapper)
         {
             _apiClient = apiClient;
+            _brandApi = brandApi;
             _mapper = mapper;
         }
 
@@ -50,6 +52,16 @@ namespace Farmacheck.Controllers
             var dto = _mapper.Map<UserDto>(entidad);
             var model = _mapper.Map<UsuarioViewModel>(dto);
             return Json(new { success = true, data = model });
+        }
+
+        [HttpGet]
+        public async Task<JsonResult> ListarMarcas(int unidadId)
+        {
+            var apiData = await _brandApi.GetBrandsByBusinessUnitAsync(unidadId);
+            var dtos = _mapper.Map<List<MarcaDto>>(apiData);
+            var marcas = _mapper.Map<List<MarcaViewModel>>(dtos);
+
+            return Json(new { success = true, data = marcas });
         }
 
         [HttpPost]

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -405,7 +405,7 @@
         }
 
         function cargarMarcas(unidadId) {
-            $.get('@Url.Action("ListarPorUnidadNegocio", "Marca")', { unidadId }, function (r) {
+            $.get('@Url.Action("ListarMarcas", "Usuario")', { unidadId }, function (r) {
                 const select = $('#selectMarcas');
                 clearSelect(select, 'marca');
                 r.data.forEach(m => select.append(`<option value="${m.id}">${m.nombre}</option>`));


### PR DESCRIPTION
## Summary
- allow `UsuarioController` to fetch brands using `BrandApiClient`
- load brands by business unit via new endpoint `ListarMarcas`
- update user view script to call the new endpoint

## Testing
- `dotnet build Farmacheck/Farmacheck.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889ad12f0a48331b04b1f5aa9237013