### PR TITLE
Preselect brands in user view based on array

### DIFF
--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -132,10 +132,12 @@
 
 @section Scripts {
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
-    
+
 
     <script>
         let choicesMarcas;
+        // Arreglo de IDs de marcas que deberán aparecer seleccionadas
+        let marcasSeleccionadas = [];
 
                 $('#modalEntidad').on('shown.bs.modal', function () {
             const unidadId = $('#unidadDeNegocioSelect').val();
@@ -255,6 +257,12 @@
                         const option = document.createElement("option");
                         option.value = marca.id;
                         option.text = marca.nombre;
+
+                        // Marcar como seleccionada si la marca está en el arreglo
+                        if (marcasSeleccionadas.includes(marca.id)) {
+                            option.selected = true;
+                        }
+
                         select.appendChild(option);
                     });
                 }
@@ -265,6 +273,11 @@
                     placeholderValue: 'Selecciona marcas...',
                     searchPlaceholderValue: 'Buscar...',
                 });
+
+                // Reflejar las marcas seleccionadas en el componente Choices
+                if (marcasSeleccionadas.length) {
+                    choicesMarcas.setChoiceByValue(marcasSeleccionadas.map(String));
+                }
 
             } catch (error) {
                 console.error("Error cargando marcas:", error);
@@ -365,6 +378,9 @@
             $('#estatus').val('true');
             $('#selectRol').val('');
             $('#tablaRoles tbody').html('<tr class="text-center text-muted" id="noRolesRow"><td colspan="4">No hay roles encontrados</td></tr>');
+
+            // Limpiar arreglo de marcas seleccionadas
+            marcasSeleccionadas = [];
 
             const marcasSelect = document.getElementById("marcasSelect");
             marcasSelect.innerHTML = '';


### PR DESCRIPTION
## Summary
- Allow user view to preselect brands loaded in `marcasSelect` from configurable array
- Clear preselected brands when resetting form

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed / 403 Forbidden)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688b0b0c98988331af06bd0ce564aa7a