### PR TITLE
Add status management and pagination to business units

### DIFF
--- a/Farmacheck.Application/Interfaces/IBusinessUnitApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IBusinessUnitApiClient.cs
@@ -1,11 +1,12 @@
 using Farmacheck.Application.Models.BusinessUnits;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface IBusinessUnitApiClient
     {
         Task<List<BusinessUnitResponse>> GetBusinessUnitsAsync();
-        Task<List<BusinessUnitResponse>> GetBusinessUnitsByPageAsync(int page, int items);
+        Task<PaginatedResponse<BusinessUnitResponse>> GetBusinessUnitsByPageAsync(int page, int items);
         Task<BusinessUnitResponse?> GetBusinessUnitAsync(int id);
         Task<int> CreateAsync(BusinessUnitRequest request);
         Task<bool> UpdateAsync(BusinessUnitRequest request);

--- a/Farmacheck.Application/Mappings/BusinessUnitProfile.cs
+++ b/Farmacheck.Application/Mappings/BusinessUnitProfile.cs
@@ -14,7 +14,8 @@ namespace Farmacheck.Application.Mappings
             .ForMember(dest => dest.Nombre, opt => opt.MapFrom(src => src.Nombre))
             .ForMember(dest => dest.Rfc, opt => opt.MapFrom(src => src.Rfc))
             .ForMember(dest => dest.Direccion, opt => opt.MapFrom(src => src.Direccion))
-            .ForMember(dest => dest.Logotipo, opt => opt.MapFrom(src => src.Logotipo));
+            .ForMember(dest => dest.Logotipo, opt => opt.MapFrom(src => src.Logotipo))
+            .ForMember(dest => dest.Estatus, opt => opt.MapFrom(src => src.Estatus));
         }
     }
 }

--- a/Farmacheck.Infrastructure/Services/BusinessUnitApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/BusinessUnitApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.BusinessUnits;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -19,10 +20,11 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<BusinessUnitResponse>();
         }
 
-        public async Task<List<BusinessUnitResponse>> GetBusinessUnitsByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<BusinessUnitResponse>> GetBusinessUnitsByPageAsync(int page, int items)
         {
             var url = $"api/v1/BusinessUnits/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<BusinessUnitResponse>>(url) ?? new List<BusinessUnitResponse>();
+            return await _http.GetFromJsonAsync<PaginatedResponse<BusinessUnitResponse>>(url)
+                ?? new PaginatedResponse<BusinessUnitResponse>(new List<BusinessUnitResponse>(), 0, page, items);
         }
 
         public async Task<BusinessUnitResponse?> GetBusinessUnitAsync(int id)

--- a/Farmacheck/Views/UnidadDeNegocio/Index.cshtml
+++ b/Farmacheck/Views/UnidadDeNegocio/Index.cshtml
@@ -29,6 +29,15 @@
         </thead>
         <tbody></tbody>
     </table>
+    <div class="d-flex justify-content-end">
+        <nav>
+            <ul class="pagination mb-0">
+                <li class="page-item"><button class="page-link" id="btnPrev">Anterior</button></li>
+                <li class="page-item"><span class="page-link" id="lblPage"></span></li>
+                <li class="page-item"><button class="page-link" id="btnNext">Siguiente</button></li>
+            </ul>
+        </nav>
+    </div>
 </div>
 
 <div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
@@ -52,6 +61,10 @@
                     <label>Dirección</label>
                     <input type="text" class="form-control" id="direccion" placeholder="Dirección" />
                 </div>
+                <div class="form-check form-switch mb-2">
+                    <input class="form-check-input" type="checkbox" id="estatusCheck" checked disabled>
+                    <label class="form-check-label" for="estatusCheck">Habilitado</label>
+                </div>
                 <div class="mb-2">
                     <label>Logotipo</label>
                     <input type="file" class="form-control" id="logotipoArchivo" accept="image/*" />
@@ -68,12 +81,28 @@
 
 @section Scripts {
     <script>
+        var pagina = @ViewBag.Page ?? 1;
+        var pageSize = 5;
+
         $(document).ready(function () {
-            cargar();
-            
+            cargar(pagina);
+
+            $('#btnPrev').click(function () {
+                if (pagina > 1) {
+                    pagina--;
+                    cargar(pagina);
+                }
+            });
+
+            $('#btnNext').click(function () {
+                pagina++;
+                cargar(pagina);
+            });
+
             $('#btnNueva').click(function () {
                 limpiar();
                 $('#modalTitulo').text('Nueva unidad');
+                $('#estatusCheck').prop('checked', true).prop('disabled', true);
                 $('#modalEntidad').modal('show');
             });
 
@@ -83,43 +112,44 @@
             });
 
             $('#btnGuardar').click(function () {
-            const id = parseInt($('#entidadId').val()) || 0;
-            const formData = new FormData();
-            formData.append('Id', id);
-            formData.append('Nombre', $('#nombre').val());
-            formData.append('Rfc', $('#rfc').val());
-            formData.append('Direccion', $('#direccion').val());
+                const id = parseInt($('#entidadId').val()) || 0;
+                const formData = new FormData();
+                formData.append('Id', id);
+                formData.append('Nombre', $('#nombre').val());
+                formData.append('Rfc', $('#rfc').val());
+                formData.append('Direccion', $('#direccion').val());
+                formData.append('Estatus', $('#estatusCheck').prop('checked'));
 
-            const file = $('#logotipoArchivo')[0].files[0];
-            if (file) {
-                formData.append('LogotipoArchivo', file);
-            }
-
-            $.ajax({
-                url: '@Url.Action("Guardar", "UnidadDeNegocio")',
-                method: 'POST',
-                data: formData,
-                processData: false,
-                contentType: false,
-                success: function (r) {
-                    if (r.success) {
-                        $('#modalEntidad').modal('hide');
-                        const mensaje = (id === 0)
-                            ? 'Unidad insertada correctamente'
-                            : 'Unidad actualizada correctamente';
-                        showAlert(mensaje, 'success');
-                        cargar();
-                    } else {
-                        showAlert(r.error || 'Error al guardar', 'error');
-                    }
+                const file = $('#logotipoArchivo')[0].files[0];
+                if (file) {
+                    formData.append('LogotipoArchivo', file);
                 }
+
+                $.ajax({
+                    url: '@Url.Action("Guardar", "UnidadDeNegocio")',
+                    method: 'POST',
+                    data: formData,
+                    processData: false,
+                    contentType: false,
+                    success: function (r) {
+                        if (r.success) {
+                            $('#modalEntidad').modal('hide');
+                            const mensaje = (id === 0)
+                                ? 'Unidad insertada correctamente'
+                                : 'Unidad actualizada correctamente';
+                            showAlert(mensaje, 'success');
+                            cargar(pagina);
+                        } else {
+                            showAlert(r.error || 'Error al guardar', 'error');
+                        }
+                    }
+                });
             });
-        });
 
         });
 
-        function cargar() {
-            $.get('@Url.Action("Listar", "UnidadDeNegocio")', function (r) {
+        function cargar(pagina) {
+            $.get('@Url.Action("Listar", "UnidadDeNegocio")', { page: pagina }, function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
                     if ($.fn.DataTable.isDataTable(tabla)) {
@@ -128,7 +158,7 @@
 
                     const tbody = tabla.find('tbody');
                     tbody.empty();
-                    r.data.forEach(u => {
+                    r.data.items.forEach(u => {
                         tbody.append(`<tr>
                             <td>${u.id}</td>
                             <td>${u.nombre}</td>
@@ -143,12 +173,18 @@
                     });
 
                     tabla.DataTable({
-                        pageLength: 5,
-                        lengthMenu: [5, 10, 25, 50, 100],
+                        paging: false,
+                        searching: true,
+                        ordering: true,
+                        info: false,
                         language: {
                             url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                         }
                     });
+
+                    $('#lblPage').text(pagina);
+                    $('#btnPrev').prop('disabled', pagina === 1);
+                    $('#btnNext').prop('disabled', !r.data.hasNextPage);
                 }
             });
         }
@@ -163,10 +199,10 @@
                     $('#rfc').val(u.rfc);
                     $('#direccion').val(u.direccion);
                     $('#logotipo').val(u.logotipoNombreArchivo);
-                    
+                    $('#estatusCheck').prop('checked', u.estatus).prop('disabled', false);
 
                     $('#logotipoArchivo').val('');
-                    
+
                     $('#modalEntidad').modal('show');
                 } else {
                     showAlert(r.error || 'No se pudo cargar', 'error');
@@ -179,7 +215,7 @@
                 if (!ok) return;
                 $.post('@Url.Action("Eliminar", "UnidadDeNegocio")', { id }, function (r) {
                     if (r.success) {
-                        cargar();
+                        cargar(pagina);
                     } else {
                         showAlert(r.error || 'Error al eliminar', 'error');
                     }
@@ -194,6 +230,7 @@
             $('#direccion').val('');
             $('#logotipo').val('');
             $('#logotipoArchivo').val('');
+            $('#estatusCheck').prop('checked', true).prop('disabled', true);
         }
     </script>
 }


### PR DESCRIPTION
## Summary
- add disabled 'Habilitado' checkbox in Business Unit modal and sync it with form actions
- implement API and controller pagination for Business Units using PaginatedResponse
- extend BusinessUnit API client and mapping to handle status field

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_688c5abc4e408331a5f4a51abeeb1f9e