### PR TITLE
feat: add customer filter client

### DIFF
--- a/Farmacheck.Application/DTOs/CustomerDto.cs
+++ b/Farmacheck.Application/DTOs/CustomerDto.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Farmacheck.Application.DTOs
 {
@@ -16,6 +17,6 @@ namespace Farmacheck.Application.DTOs
         public bool Estatus { get; set; }
         public short RadioGps { get; set; }
         public short TipoDeClienteId { get; set; }
-        public BusinessStructureDto BusinessStructure { get; set; } = null!;
+        public IEnumerable<BusinessStructureDto> BusinessStructure { get; set; } = null!;
     }
 }

--- a/Farmacheck.Application/Interfaces/ICustomersApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ICustomersApiClient.cs
@@ -6,6 +6,7 @@ namespace Farmacheck.Application.Interfaces
     {
         Task<List<CustomerResponse>> GetCustomersAsync();
         Task<List<CustomerResponse>> GetCustomersByPageAsync(int page, int items);
+        Task<List<CustomerResponse>> GetCustomersByFiltersAsync(IEnumerable<int> subbrand, IEnumerable<int> zone);
         Task<CustomerResponse?> GetCustomerAsync(int id);
         Task<int> CreateAsync(CustomerRequest request);
         Task<bool> UpdateAsync(UpdateCustomerRequest request);

--- a/Farmacheck.Application/Models/Customers/CustomerRequest.cs
+++ b/Farmacheck.Application/Models/Customers/CustomerRequest.cs
@@ -2,7 +2,7 @@ namespace Farmacheck.Application.Models.Customers
 {
     public class CustomerRequest
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
         public string CentroDeCosto { get; set; } = null!;
         public string Nombre { get; set; } = null!;
         public string Direccion { get; set; } = null!;

--- a/Farmacheck.Application/Models/Customers/CustomerResponse.cs
+++ b/Farmacheck.Application/Models/Customers/CustomerResponse.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Farmacheck.Application.Models.Customers
 {
     public class CustomerResponse
@@ -14,6 +16,6 @@ namespace Farmacheck.Application.Models.Customers
         public bool Estatus { get; set; }
         public short RadioGps { get; set; }
         public short TipoDeClienteId { get; set; }
-        public BusinessStructureResponse BusinessStructure { get; set; } = null!;
+        public IEnumerable<BusinessStructureResponse> BusinessStructure { get; set; } = null!;
     }
 }

--- a/Farmacheck.Application/Models/Customers/UpdateCustomerRequest.cs
+++ b/Farmacheck.Application/Models/Customers/UpdateCustomerRequest.cs
@@ -2,7 +2,6 @@ namespace Farmacheck.Application.Models.Customers
 {
     public class UpdateCustomerRequest : CustomerRequest
     {
-        public int Id { get; set; }
-        public bool? Estatus { get; set; }
+        public bool Estatus { get; set; }
     }
 }

--- a/Farmacheck.Infrastructure/Services/CustomersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CustomersApiClient.cs
@@ -1,6 +1,7 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Customers;
 using System.Net.Http.Json;
+using System.Linq;
 
 namespace Farmacheck.Infrastructure.Services
 {
@@ -22,6 +23,28 @@ namespace Farmacheck.Infrastructure.Services
         public async Task<List<CustomerResponse>> GetCustomersByPageAsync(int page, int items)
         {
             var url = $"api/v1/Customers/pages?page={page}&items={items}";
+            return await _http.GetFromJsonAsync<List<CustomerResponse>>(url)
+                   ?? new List<CustomerResponse>();
+        }
+
+        public async Task<List<CustomerResponse>> GetCustomersByFiltersAsync(IEnumerable<int> subbrand, IEnumerable<int> zone)
+        {
+            var query = new List<string>();
+            if (subbrand != null && subbrand.Any())
+            {
+                query.Add(string.Join("&", subbrand.Select(s => $"subbrand={s}")));
+            }
+            if (zone != null && zone.Any())
+            {
+                query.Add(string.Join("&", zone.Select(z => $"zone={z}")));
+            }
+
+            var url = "api/v1/Customers/filters";
+            if (query.Any())
+            {
+                url += "?" + string.Join("&", query);
+            }
+
             return await _http.GetFromJsonAsync<List<CustomerResponse>>(url)
                    ?? new List<CustomerResponse>();
         }

--- a/Farmacheck/Helpers/WebMappingProfile.cs
+++ b/Farmacheck/Helpers/WebMappingProfile.cs
@@ -12,6 +12,7 @@ using Farmacheck.Application.Models.CategoriesByQuestionnaires;
 using Farmacheck.Application.Models.Roles;
 using Farmacheck.Application.Models.HierarchyByRoles;
 using Farmacheck.Application.Models.Users;
+using System.Linq;
 
 namespace Farmacheck.Helpers
 {
@@ -51,10 +52,10 @@ namespace Farmacheck.Helpers
 
             CreateMap<CustomerDto, ClienteEstructuraViewModel>()
                 .ForMember(dest => dest.ClienteId, opt => opt.MapFrom(src => src.Id))
-                .ForMember(dest => dest.UnidadDeNegocioId, opt => opt.MapFrom(src => src.BusinessStructure.UnidadDeNegocioId))
-                .ForMember(dest => dest.MarcaId, opt => opt.MapFrom(src => src.BusinessStructure.MarcaId))
-                .ForMember(dest => dest.SubmarcaId, opt => opt.MapFrom(src => src.BusinessStructure.SubmarcaId))
-                .ForMember(dest => dest.ZonaId, opt => opt.MapFrom(src => src.BusinessStructure.ZonaId))
+                .ForMember(dest => dest.UnidadDeNegocioId, opt => opt.MapFrom(src => src.BusinessStructure.FirstOrDefault()?.UnidadDeNegocioId))
+                .ForMember(dest => dest.MarcaId, opt => opt.MapFrom(src => src.BusinessStructure.FirstOrDefault()?.MarcaId))
+                .ForMember(dest => dest.SubmarcaId, opt => opt.MapFrom(src => src.BusinessStructure.FirstOrDefault()?.SubmarcaId))
+                .ForMember(dest => dest.ZonaId, opt => opt.MapFrom(src => src.BusinessStructure.FirstOrDefault()?.ZonaId))
                 .ForMember(dest => dest.LatitudGPS, opt => opt.MapFrom(src => (int?)src.LatitudGps))
                 .ForMember(dest => dest.LongitudGPS, opt => opt.MapFrom(src => (int?)src.LongitudGps))
                 .ForMember(dest => dest.ModificadoEl, opt => opt.MapFrom(src => src.ModificadoEl))


### PR DESCRIPTION
## Summary
- expand customer models and DTOs to support multiple business structures
- expose filter method for customers API client
- adjust mapping to handle list-based business structures

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e8cad08dc83318a56162396f8fbc6