### PR TITLE
Add roles-by-user support to customers API client

### DIFF
--- a/Farmacheck.Application/Interfaces/ICustomersApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ICustomersApiClient.cs
@@ -1,4 +1,5 @@
 using Farmacheck.Application.Models.Customers;
+using Farmacheck.Application.Models.BusinessUnits;
 
 namespace Farmacheck.Application.Interfaces
 {
@@ -7,6 +8,7 @@ namespace Farmacheck.Application.Interfaces
         Task<List<CustomerResponse>> GetCustomersAsync();
         Task<List<CustomerResponse>> GetCustomersByPageAsync(int page, int items);
         Task<List<CustomerResponse>> GetCustomersByFiltersAsync(IEnumerable<int> subbrand, IEnumerable<int> zone);
+        Task<List<BusinessUnitResponse>> GetRolesByUserAsync(int rolByUser);
         Task<CustomerResponse?> GetCustomerAsync(int id);
         Task<int> CreateAsync(CustomerRequest request);
         Task<bool> UpdateAsync(UpdateCustomerRequest request);

--- a/Farmacheck.Infrastructure/Services/CustomersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CustomersApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Customers;
+using Farmacheck.Application.Models.BusinessUnits;
 using System.Net.Http.Json;
 using System.Linq;
 
@@ -47,6 +48,12 @@ namespace Farmacheck.Infrastructure.Services
 
             return await _http.GetFromJsonAsync<List<CustomerResponse>>(url)
                    ?? new List<CustomerResponse>();
+        }
+
+        public async Task<List<BusinessUnitResponse>> GetRolesByUserAsync(int rolByUser)
+        {
+            return await _http.GetFromJsonAsync<List<BusinessUnitResponse>>($"api/v1/Customers/rolesPorUsuario/{rolByUser}")
+                   ?? new List<BusinessUnitResponse>();
         }
 
         public async Task<CustomerResponse?> GetCustomerAsync(int id)


### PR DESCRIPTION
## Summary
- Extend customers API client and interface with `GetRolesByUserAsync`
- Include business unit models to enable role-based customer queries

## Testing
- `dotnet test Farmacheck/Farmacheck.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688ee9b8b1608331bcb7fdebbd36992a