### PR TITLE
Add endpoint for client assignments by user role

### DIFF
--- a/Farmacheck.Application/DTOs/AssignedClientsByUserRoleDto.cs
+++ b/Farmacheck.Application/DTOs/AssignedClientsByUserRoleDto.cs
@@ -1,0 +1,10 @@
+namespace Farmacheck.Application.DTOs
+{
+    public class AssignedClientsByUserRoleDto
+    {
+        public int UserRoleId { get; set; }
+        public string RoleName { get; set; } = null!;
+        public string BusinessUnitName { get; set; } = null!;
+        public int TotalClients { get; set; }
+    }
+}

--- a/Farmacheck.Application/Interfaces/IAssignedClientsByUserRoleApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IAssignedClientsByUserRoleApiClient.cs
@@ -1,0 +1,9 @@
+using Farmacheck.Application.Models.AssignedClientsByUserRole;
+
+namespace Farmacheck.Application.Interfaces
+{
+    public interface IAssignedClientsByUserRoleApiClient
+    {
+        Task<AssignedClientsByUserRoleResponse?> GetByUserRoleAsync(int userRoleId);
+    }
+}

--- a/Farmacheck.Application/Mappings/AssignedClientsByUserRoleProfile.cs
+++ b/Farmacheck.Application/Mappings/AssignedClientsByUserRoleProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Application.Models.AssignedClientsByUserRole;
+
+namespace Farmacheck.Application.Mappings
+{
+    public class AssignedClientsByUserRoleProfile : Profile
+    {
+        public AssignedClientsByUserRoleProfile()
+        {
+            CreateMap<AssignedClientsByUserRoleResponse, AssignedClientsByUserRoleDto>().ReverseMap();
+        }
+    }
+}

--- a/Farmacheck.Application/Models/AssignedClientsByUserRole/AssignedClientsByUserRoleResponse.cs
+++ b/Farmacheck.Application/Models/AssignedClientsByUserRole/AssignedClientsByUserRoleResponse.cs
@@ -1,0 +1,10 @@
+namespace Farmacheck.Application.Models.AssignedClientsByUserRole
+{
+    public class AssignedClientsByUserRoleResponse
+    {
+        public int UserRoleId { get; set; }
+        public string RoleName { get; set; } = null!;
+        public string BusinessUnitName { get; set; } = null!;
+        public int TotalClients { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/DependencyInjection.cs
+++ b/Farmacheck.Infrastructure/DependencyInjection.cs
@@ -69,6 +69,11 @@ public static class DependencyInjection
             client.BaseAddress = new Uri(configuration["UsersApi:BaseUrl"]!);
         });
 
+        services.AddHttpClient<IAssignedClientsByUserRoleApiClient, AssignedClientsByUserRoleApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["AssignedClientsByUserRoleApi:BaseUrl"]!);
+        });
+
         return services;
     }
 }

--- a/Farmacheck.Infrastructure/Services/AssignedClientsByUserRoleApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/AssignedClientsByUserRoleApiClient.cs
@@ -1,0 +1,21 @@
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.AssignedClientsByUserRole;
+using System.Net.Http.Json;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    public class AssignedClientsByUserRoleApiClient : IAssignedClientsByUserRoleApiClient
+    {
+        private readonly HttpClient _http;
+
+        public AssignedClientsByUserRoleApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<AssignedClientsByUserRoleResponse?> GetByUserRoleAsync(int userRoleId)
+        {
+            return await _http.GetFromJsonAsync<AssignedClientsByUserRoleResponse>($"api/v1/ClientesAsignadosARolPorUsuario/{userRoleId}");
+        }
+    }
+}

--- a/Farmacheck/Controllers/ClientesAsignadosARolPorUsuarioController.cs
+++ b/Farmacheck/Controllers/ClientesAsignadosARolPorUsuarioController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using AutoMapper;
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Models;
+
+namespace Farmacheck.Controllers
+{
+    public class ClientesAsignadosARolPorUsuarioController : Controller
+    {
+        private readonly IAssignedClientsByUserRoleApiClient _apiClient;
+        private readonly IMapper _mapper;
+
+        public ClientesAsignadosARolPorUsuarioController(IAssignedClientsByUserRoleApiClient apiClient, IMapper mapper)
+        {
+            _apiClient = apiClient;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public async Task<JsonResult> Obtener(int rolPorUsuarioId)
+        {
+            var apiData = await _apiClient.GetByUserRoleAsync(rolPorUsuarioId);
+            if (apiData == null)
+                return Json(new { success = false, error = "No encontrado" });
+
+            var dto = _mapper.Map<AssignedClientsByUserRoleDto>(apiData);
+            var model = _mapper.Map<ClientesAsignadosARolPorUsuarioViewModel>(dto);
+            return Json(new { success = true, data = model });
+        }
+    }
+}

--- a/Farmacheck/Helpers/WebMappingProfile.cs
+++ b/Farmacheck/Helpers/WebMappingProfile.cs
@@ -129,6 +129,7 @@ namespace Farmacheck.Helpers
             CreateMap<UsuarioViewModel, UserRequest>();
             CreateMap<UsuarioViewModel, UpdateUserRequest>();
             CreateMap<UserByRoleDto, UsuarioRolViewModel>().ReverseMap();
+            CreateMap<AssignedClientsByUserRoleDto, ClientesAsignadosARolPorUsuarioViewModel>().ReverseMap();
         }
     }
 }

--- a/Farmacheck/Models/ClientesAsignadosARolPorUsuarioViewModel.cs
+++ b/Farmacheck/Models/ClientesAsignadosARolPorUsuarioViewModel.cs
@@ -1,0 +1,10 @@
+namespace Farmacheck.Models
+{
+    public class ClientesAsignadosARolPorUsuarioViewModel
+    {
+        public int RolPorUsuarioId { get; set; }
+        public string RolNombre { get; set; } = null!;
+        public string UnidadDeNegocioNombre { get; set; } = null!;
+        public int TotalClientes { get; set; }
+    }
+}

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -28,7 +28,8 @@ namespace Farmacheck
                 typeof(RoleProfile),
                 typeof(PermissionProfile),
                 typeof(HierarchyByRoleProfile),
-                typeof(UserProfile));
+                typeof(UserProfile),
+                typeof(AssignedClientsByUserRoleProfile));
 
             builder.Services.AddInfrastructure(builder.Configuration);
 

--- a/Farmacheck/appsettings.json
+++ b/Farmacheck/appsettings.json
@@ -41,6 +41,9 @@
   },
   "UsersApi": {
     "BaseUrl": "https://localhost:7205"
+  },
+  "AssignedClientsByUserRoleApi": {
+    "BaseUrl": "https://localhost:7205"
   }
 
 


### PR DESCRIPTION
## Summary
- add API client and model to retrieve assigned client counts by user role
- register new service and configuration for assigned client lookup
- expose ClientesAsignadosARolPorUsuario endpoint to return role, business unit and client totals

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fa0336dc08331aa2a58ace47e0021