### PR TITLE
Add ClientesAsignadosArolPorUsuarios API client and models

### DIFF
--- a/Farmacheck.Application/Interfaces/IClientesAsignadosArolPorUsuariosApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IClientesAsignadosArolPorUsuariosApiClient.cs
@@ -1,0 +1,15 @@
+using Farmacheck.Application.Models.ClientesAsignadosArolPorUsuarios;
+
+namespace Farmacheck.Application.Interfaces
+{
+    public interface IClientesAsignadosArolPorUsuariosApiClient
+    {
+        Task<List<ClientesAsignadosArolPorUsuarioResponse>> GetClientesAsignadosAsync();
+        Task<List<ClientesAsignadosArolPorUsuarioResponse>> GetClientesAsignadosByPageAsync(int page, int items);
+        Task<ClientesAsignadosArolPorUsuarioResponse?> GetClienteAsignadoAsync(int id);
+        Task<List<RolPorUsuarioClientesAsignadosResponse>> GetCountByRolPorUsuarioAsync(List<int> rolPorUsuarioIds, int usuarioId);
+        Task<int> CreateAsync(ClientesAsignadosArolPorUsuarioRequest request);
+        Task<bool> UpdateAsync(UpdateClientesAsignadosArolPorUsuarioRequest request);
+        Task DeleteAsync(int id);
+    }
+}

--- a/Farmacheck.Application/Models/ClientesAsignadosArolPorUsuarios/ClientesAsignadosArolPorUsuarioRequest.cs
+++ b/Farmacheck.Application/Models/ClientesAsignadosArolPorUsuarios/ClientesAsignadosArolPorUsuarioRequest.cs
@@ -1,0 +1,9 @@
+namespace Farmacheck.Application.Models.ClientesAsignadosArolPorUsuarios
+{
+    public class ClientesAsignadosArolPorUsuarioRequest
+    {
+        public int RolPorUsuarioId { get; set; }
+        public long ClienteId { get; set; }
+        public bool GeolocalizacionActiva { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/ClientesAsignadosArolPorUsuarios/ClientesAsignadosArolPorUsuarioResponse.cs
+++ b/Farmacheck.Application/Models/ClientesAsignadosArolPorUsuarios/ClientesAsignadosArolPorUsuarioResponse.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Farmacheck.Application.Models.ClientesAsignadosArolPorUsuarios
+{
+    public class ClientesAsignadosArolPorUsuarioResponse
+    {
+        public int Id { get; set; }
+        public int RolPorUsuarioId { get; set; }
+        public long ClienteId { get; set; }
+        public DateTime AsignadoEl { get; set; }
+        public bool Estatus { get; set; }
+        public bool GeolocalizacionActiva { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/ClientesAsignadosArolPorUsuarios/RolPorUsuarioClientesAsignadosResponse.cs
+++ b/Farmacheck.Application/Models/ClientesAsignadosArolPorUsuarios/RolPorUsuarioClientesAsignadosResponse.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Farmacheck.Application.Models.ClientesAsignadosArolPorUsuarios
+{
+    public class RolPorUsuarioClientesAsignadosResponse
+    {
+        public int RolPorUsuarioId { get; set; }
+        public int RolId { get; set; }
+        public string RoleNombre { get; set; } = string.Empty;
+        public int UnidadDeNegocioId { get; set; }
+        public string UnidadDeNegocioNombre { get; set; } = string.Empty;
+        public int TotalClientesAsignados { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/ClientesAsignadosArolPorUsuarios/UpdateClientesAsignadosArolPorUsuarioRequest.cs
+++ b/Farmacheck.Application/Models/ClientesAsignadosArolPorUsuarios/UpdateClientesAsignadosArolPorUsuarioRequest.cs
@@ -1,0 +1,9 @@
+namespace Farmacheck.Application.Models.ClientesAsignadosArolPorUsuarios
+{
+    public class UpdateClientesAsignadosArolPorUsuarioRequest : ClientesAsignadosArolPorUsuarioRequest
+    {
+        public int Id { get; set; }
+        public bool? Estatus { get; set; }
+        public new bool? GeolocalizacionActiva { get; set; }
+    }
+}

--- a/Farmacheck.Infrastructure/DependencyInjection.cs
+++ b/Farmacheck.Infrastructure/DependencyInjection.cs
@@ -69,6 +69,11 @@ public static class DependencyInjection
             client.BaseAddress = new Uri(configuration["UsersApi:BaseUrl"]!);
         });
 
+        services.AddHttpClient<IClientesAsignadosArolPorUsuariosApiClient, ClientesAsignadosArolPorUsuariosApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["ClientesAsignadosArolPorUsuariosApi:BaseUrl"]!);
+        });
+
         return services;
     }
 }

--- a/Farmacheck.Infrastructure/Services/ClientesAsignadosArolPorUsuariosApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/ClientesAsignadosArolPorUsuariosApiClient.cs
@@ -1,0 +1,63 @@
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.ClientesAsignadosArolPorUsuarios;
+using System.Net.Http.Json;
+using System.Linq;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    public class ClientesAsignadosArolPorUsuariosApiClient : IClientesAsignadosArolPorUsuariosApiClient
+    {
+        private readonly HttpClient _http;
+
+        public ClientesAsignadosArolPorUsuariosApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<ClientesAsignadosArolPorUsuarioResponse>> GetClientesAsignadosAsync()
+        {
+            return await _http.GetFromJsonAsync<List<ClientesAsignadosArolPorUsuarioResponse>>("api/v1/ClientesAsignadosArolPorUsuarios")
+                   ?? new List<ClientesAsignadosArolPorUsuarioResponse>();
+        }
+
+        public async Task<List<ClientesAsignadosArolPorUsuarioResponse>> GetClientesAsignadosByPageAsync(int page, int items)
+        {
+            var url = $"api/v1/ClientesAsignadosArolPorUsuarios/pages?page={page}&items={items}";
+            return await _http.GetFromJsonAsync<List<ClientesAsignadosArolPorUsuarioResponse>>(url)
+                   ?? new List<ClientesAsignadosArolPorUsuarioResponse>();
+        }
+
+        public async Task<ClientesAsignadosArolPorUsuarioResponse?> GetClienteAsignadoAsync(int id)
+        {
+            return await _http.GetFromJsonAsync<ClientesAsignadosArolPorUsuarioResponse>($"api/v1/ClientesAsignadosArolPorUsuarios/{id}");
+        }
+
+        public async Task<List<RolPorUsuarioClientesAsignadosResponse>> GetCountByRolPorUsuarioAsync(List<int> rolPorUsuarioIds, int usuarioId)
+        {
+            var query = string.Join("&", rolPorUsuarioIds.Select(id => $"rolPorUsuarioIds={id}"));
+            var url = $"api/v1/ClientesAsignadosArolPorUsuarios/rolPorUsuario/usuario/{usuarioId}?{query}";
+            return await _http.GetFromJsonAsync<List<RolPorUsuarioClientesAsignadosResponse>>(url)
+                   ?? new List<RolPorUsuarioClientesAsignadosResponse>();
+        }
+
+        public async Task<int> CreateAsync(ClientesAsignadosArolPorUsuarioRequest request)
+        {
+            var response = await _http.PostAsJsonAsync("api/v1/ClientesAsignadosArolPorUsuarios", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<int>();
+        }
+
+        public async Task<bool> UpdateAsync(UpdateClientesAsignadosArolPorUsuarioRequest request)
+        {
+            var response = await _http.PutAsJsonAsync("api/v1/ClientesAsignadosArolPorUsuarios", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<bool>();
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            var response = await _http.DeleteAsync($"api/v1/ClientesAsignadosArolPorUsuarios/{id}");
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add client for ClientesAsignadosArolPorUsuarios API
- add request and response models for assigned clients
- register new client in DI

## Testing
- `dotnet build Farmacheck.Application/Farmacheck.Application.csproj` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688fe86d2a9083318a7b086f81ee4b8c