### PR TITLE
Add role-based client count retrieval to user management

### DIFF
--- a/Farmacheck.Application/DTOs/RolPorUsuarioClientesAsignadosDto.cs
+++ b/Farmacheck.Application/DTOs/RolPorUsuarioClientesAsignadosDto.cs
@@ -1,0 +1,12 @@
+namespace Farmacheck.Application.DTOs
+{
+    public class RolPorUsuarioClientesAsignadosDto
+    {
+        public int RolPorUsuarioId { get; set; }
+        public int RolId { get; set; }
+        public string RoleNombre { get; set; } = string.Empty;
+        public int UnidadDeNegocioId { get; set; }
+        public string UnidadDeNegocioNombre { get; set; } = string.Empty;
+        public int TotalClientesAsignados { get; set; }
+    }
+}

--- a/Farmacheck.Application/Mappings/ClientesAsignadosArolPorUsuariosProfile.cs
+++ b/Farmacheck.Application/Mappings/ClientesAsignadosArolPorUsuariosProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Application.Models.ClientesAsignadosArolPorUsuarios;
+
+namespace Farmacheck.Application.Mappings
+{
+    public class ClientesAsignadosArolPorUsuariosProfile : Profile
+    {
+        public ClientesAsignadosArolPorUsuariosProfile()
+        {
+            CreateMap<RolPorUsuarioClientesAsignadosResponse, RolPorUsuarioClientesAsignadosDto>().ReverseMap();
+        }
+    }
+}

--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -150,6 +150,16 @@ namespace Farmacheck.Controllers
             return Json(new { success = true, data = roles });
         }
 
+        [HttpGet]
+        public async Task<JsonResult> ListarRolPorUsuarioCount(List<int> rolPorUsuarioIds, int usuarioId)
+        {
+            var apiData = await _clientesAsignadosArolPorUsuariosApiClient.GetCountByRolPorUsuarioAsync(rolPorUsuarioIds, usuarioId);
+            var dtos = _mapper.Map<List<RolPorUsuarioClientesAsignadosDto>>(apiData);
+            var counts = _mapper.Map<List<RolPorUsuarioClientesAsignadosViewModel>>(dtos);
+
+            return Json(new { success = true, data = counts });
+        }
+
         
     }
 }

--- a/Farmacheck/Helpers/WebMappingProfile.cs
+++ b/Farmacheck/Helpers/WebMappingProfile.cs
@@ -129,6 +129,7 @@ namespace Farmacheck.Helpers
             CreateMap<UsuarioViewModel, UserRequest>();
             CreateMap<UsuarioViewModel, UpdateUserRequest>();
             CreateMap<UserByRoleDto, UsuarioRolViewModel>().ReverseMap();
+            CreateMap<RolPorUsuarioClientesAsignadosDto, RolPorUsuarioClientesAsignadosViewModel>().ReverseMap();
         }
     }
 }

--- a/Farmacheck/Models/RolPorUsuarioClientesAsignadosViewModel.cs
+++ b/Farmacheck/Models/RolPorUsuarioClientesAsignadosViewModel.cs
@@ -1,0 +1,12 @@
+namespace Farmacheck.Models
+{
+    public class RolPorUsuarioClientesAsignadosViewModel
+    {
+        public int RolPorUsuarioId { get; set; }
+        public int RolId { get; set; }
+        public string RoleNombre { get; set; } = string.Empty;
+        public int UnidadDeNegocioId { get; set; }
+        public string UnidadDeNegocioNombre { get; set; } = string.Empty;
+        public int TotalClientesAsignados { get; set; }
+    }
+}

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -200,6 +200,24 @@
 
                 cargarSubMarcas(seleccionadas);
             });
+
+            $('#selectRol').change(function () {
+                const rolPorUsuarioId = $(this).val();
+                const usuarioId = $('#entidadId').val() || 0;
+                if (rolPorUsuarioId) {
+                    $.ajax({
+                        url: '@Url.Action("ListarRolPorUsuarioCount", "Usuario")',
+                        method: 'GET',
+                        traditional: true,
+                        data: { rolPorUsuarioIds: [rolPorUsuarioId], usuarioId: usuarioId },
+                        success: function (r) {
+                            if (r.success) {
+                                console.log(r.data);
+                            }
+                        }
+                    });
+                }
+            });
             $('#btnNuevo').click(function () {
                 limpiar();
                 $('#modalTitulo').text('Nuevo usuario');


### PR DESCRIPTION
## Summary
- Add DTO, view model, and mappings for role client assignments
- Implement ListarRolPorUsuarioCount in UsuarioController
- Trigger role-based client count retrieval on role selection change in view

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6890039441b4833183c6b53d47bd8d39