### PR TITLE
Add UsersByRoles API client and models

### DIFF
--- a/Farmacheck.Application/Interfaces/IUserByRoleApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IUserByRoleApiClient.cs
@@ -1,0 +1,15 @@
+using Farmacheck.Application.Models.Users;
+
+namespace Farmacheck.Application.Interfaces
+{
+    public interface IUserByRoleApiClient
+    {
+        Task<List<UserByRoleResponse>> GetUsersByRolesAsync();
+        Task<List<UserByRoleResponse>> GetUsersByRolesByPageAsync(int page, int items);
+        Task<UserByRoleResponse?> GetUserByRoleAsync(int id);
+        Task<List<UserByRoleResponse>> GetByUserAsync(int usuarioId);
+        Task<int> CreateAsync(UserByRoleRequest request);
+        Task<bool> UpdateAsync(UpdateUserByRoleRequest request);
+        Task<bool> DeleteAsync(int id);
+    }
+}

--- a/Farmacheck.Application/Models/Users/UpdateUserByRoleRequest.cs
+++ b/Farmacheck.Application/Models/Users/UpdateUserByRoleRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Farmacheck.Application.Models.Users
+{
+    public class UpdateUserByRoleRequest : UserByRoleRequest
+    {
+        [Required]
+        public int Id { get; set; }
+        public bool Estatus { get; set; }
+    }
+}

--- a/Farmacheck.Application/Models/Users/UserByRoleRequest.cs
+++ b/Farmacheck.Application/Models/Users/UserByRoleRequest.cs
@@ -1,0 +1,11 @@
+namespace Farmacheck.Application.Models.Users
+{
+    public class UserByRoleRequest
+    {
+        public int UsuarioId { get; set; }
+        public int RolId { get; set; }
+        public int UnidadDeNegocioId { get; set; }
+        public int AsignadoPor { get; set; }
+        public IEnumerable<long> ClienteIds { get; set; } = new List<long>();
+    }
+}

--- a/Farmacheck.Infrastructure/DependencyInjection.cs
+++ b/Farmacheck.Infrastructure/DependencyInjection.cs
@@ -69,6 +69,11 @@ public static class DependencyInjection
             client.BaseAddress = new Uri(configuration["UsersApi:BaseUrl"]!);
         });
 
+        services.AddHttpClient<IUserByRoleApiClient, UsersByRolesApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["UsersByRolesApi:BaseUrl"]!);
+        });
+
         services.AddHttpClient<IClientesAsignadosArolPorUsuariosApiClient, ClientesAsignadosArolPorUsuariosApiClient>(client =>
         {
             client.BaseAddress = new Uri(configuration["ClientesAsignadosArolPorUsuariosApi:BaseUrl"]!);

--- a/Farmacheck.Infrastructure/Services/UsersByRolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/UsersByRolesApiClient.cs
@@ -1,0 +1,61 @@
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.Users;
+using System.Net.Http.Json;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    public class UsersByRolesApiClient : IUserByRoleApiClient
+    {
+        private readonly HttpClient _http;
+
+        public UsersByRolesApiClient(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<UserByRoleResponse>> GetUsersByRolesAsync()
+        {
+            return await _http.GetFromJsonAsync<List<UserByRoleResponse>>("api/v1/UsersByRoles")
+                   ?? new List<UserByRoleResponse>();
+        }
+
+        public async Task<List<UserByRoleResponse>> GetUsersByRolesByPageAsync(int page, int items)
+        {
+            var url = $"api/v1/UsersByRoles/pages?page={page}&items={items}";
+            return await _http.GetFromJsonAsync<List<UserByRoleResponse>>(url)
+                   ?? new List<UserByRoleResponse>();
+        }
+
+        public async Task<UserByRoleResponse?> GetUserByRoleAsync(int id)
+        {
+            return await _http.GetFromJsonAsync<UserByRoleResponse>($"api/v1/UsersByRoles/{id}");
+        }
+
+        public async Task<List<UserByRoleResponse>> GetByUserAsync(int usuarioId)
+        {
+            return await _http.GetFromJsonAsync<List<UserByRoleResponse>>($"api/v1/UsersByRoles/user/{usuarioId}")
+                   ?? new List<UserByRoleResponse>();
+        }
+
+        public async Task<int> CreateAsync(UserByRoleRequest request)
+        {
+            var response = await _http.PostAsJsonAsync("api/v1/UsersByRoles", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<int>();
+        }
+
+        public async Task<bool> UpdateAsync(UpdateUserByRoleRequest request)
+        {
+            var response = await _http.PutAsJsonAsync("api/v1/UsersByRoles", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<bool>();
+        }
+
+        public async Task<bool> DeleteAsync(int id)
+        {
+            var response = await _http.DeleteAsync($"api/v1/UsersByRoles/{id}");
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<bool>();
+        }
+    }
+}

--- a/Farmacheck/Helpers/WebMappingProfile.cs
+++ b/Farmacheck/Helpers/WebMappingProfile.cs
@@ -129,6 +129,8 @@ namespace Farmacheck.Helpers
             CreateMap<UsuarioViewModel, UserRequest>();
             CreateMap<UsuarioViewModel, UpdateUserRequest>();
             CreateMap<UserByRoleDto, UsuarioRolViewModel>().ReverseMap();
+            CreateMap<UsuarioRolViewModel, UserByRoleRequest>();
+            CreateMap<UsuarioRolViewModel, UpdateUserByRoleRequest>();
             CreateMap<RolPorUsuarioClientesAsignadosDto, RolPorUsuarioClientesAsignadosViewModel>().ReverseMap();
         }
     }

--- a/Farmacheck/Models/UsuarioRolViewModel.cs
+++ b/Farmacheck/Models/UsuarioRolViewModel.cs
@@ -9,5 +9,7 @@ namespace Farmacheck.Models
         public DateTime AsignadoEl { get; set; }
         public int AsignadoPor { get; set; }
         public bool Estatus { get; set; }
+        public int UnidadDeNegocioId { get; set; }
+        public List<long> ClienteIds { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- Add request and update models for assigning roles to users
- Implement UsersByRoles API client and register in DI
- Map UsuarioRol view models to new request models

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68903da27c8c8331b74e2ba2b02c59fb