### PR TITLE
Add handler for user role assignment registration

### DIFF
--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -20,8 +20,9 @@ namespace Farmacheck.Controllers
         private readonly IZoneApiClient _zoneApi;
         private readonly IClientesAsignadosArolPorUsuariosApiClient _clientesAsignadosArolPorUsuariosApiClient;
         private readonly ICustomersApiClient _customersApi;
+        private readonly IUserByRoleApiClient _userByRoleApiClient;
 
-        public UsuarioController(IUserApiClient apiClient, IBrandApiClient brandApi, IMapper mapper, IBusinessUnitApiClient businessUnitApi, ISubbrandApiClient subbrandApi, IZoneApiClient zoneApi,IClientesAsignadosArolPorUsuariosApiClient clientesAsignadosArolPorUsuariosApiClient, ICustomersApiClient customersApi)
+        public UsuarioController(IUserApiClient apiClient, IBrandApiClient brandApi, IMapper mapper, IBusinessUnitApiClient businessUnitApi, ISubbrandApiClient subbrandApi, IZoneApiClient zoneApi,IClientesAsignadosArolPorUsuariosApiClient clientesAsignadosArolPorUsuariosApiClient, ICustomersApiClient customersApi, IUserByRoleApiClient userByRoleApiClient)
         {
             _apiClient = apiClient;
             _brandApi = brandApi;
@@ -31,6 +32,7 @@ namespace Farmacheck.Controllers
             _zoneApi = zoneApi;
             _clientesAsignadosArolPorUsuariosApiClient = clientesAsignadosArolPorUsuariosApiClient;
             _customersApi = customersApi;
+            _userByRoleApiClient = userByRoleApiClient;
         }
 
         public async Task<IActionResult> Index()
@@ -112,6 +114,21 @@ namespace Farmacheck.Controllers
             var clientes = _mapper.Map<List<ClienteEstructuraViewModel>>(dtos);
 
             return Json(new { success = true, data = clientes });
+        }
+
+        [HttpPost]
+        public async Task<JsonResult> GuardarRolPorUsuario([FromBody] UsuarioRolViewModel model)
+        {
+            try
+            {
+                var request = _mapper.Map<UserByRoleRequest>(model);
+                var id = await _userByRoleApiClient.CreateAsync(request);
+                return Json(new { success = true, id });
+            }
+            catch (Exception ex)
+            {
+                return Json(new { success = false, error = "Ocurrió un error inesperado: " + ex.Message });
+            }
         }
 
         [HttpPost]

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -360,6 +360,51 @@
                     }
                 });
             });
+
+            $('#btnGuardarRol').click(function () {
+                const usuarioId = $('#entidadId').val();
+                const rolId = $('#rolSelectModal').val();
+                const unidadId = $('#unidadDeNegocioSelect').val();
+                const clienteIds = $('#contenedorClientes .cliente-check:checked').map(function () {
+                    return parseInt(this.value);
+                }).get();
+
+                if (!rolId) {
+                    showAlert('Selecciona un rol', 'warning');
+                    return;
+                }
+                if (!unidadId) {
+                    showAlert('Selecciona una unidad de negocio', 'warning');
+                    return;
+                }
+                if (clienteIds.length === 0) {
+                    showAlert('Selecciona al menos un cliente', 'warning');
+                    return;
+                }
+
+                const datos = {
+                    UsuarioId: parseInt(usuarioId),
+                    RolId: parseInt(rolId),
+                    UnidadDeNegocioId: parseInt(unidadId),
+                    AsignadoPor: 1,
+                    ClienteIds: clienteIds
+                };
+
+                $.ajax({
+                    url: '@Url.Action("GuardarRolPorUsuario", "Usuario")',
+                    method: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify(datos),
+                    success: function (r) {
+                        if (r.success) {
+                            showAlert('El registro de clientes asignados a rol por usuario se realizó correctamente', 'success');
+                            $('#modalGestionRol').modal('hide');
+                        } else {
+                            showAlert(r.error || 'Error al guardar', 'error');
+                        }
+                    }
+                });
+            });
         });
 
         async function cargarUnidadesNegocio() {


### PR DESCRIPTION
## Summary
- collect role, business unit and client selections and submit via new GuardarRolPorUsuario endpoint
- wire UsuarioController to IUserByRoleApiClient to persist user-role-client assignments

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden repositories)*

------
https://chatgpt.com/codex/tasks/task_e_689042ec7a388331bd0cc88e8f7a7a39