### PR TITLE
Retrieve role permissions for role editor

### DIFF
--- a/Farmacheck/Controllers/RolController.cs
+++ b/Farmacheck/Controllers/RolController.cs
@@ -106,21 +106,21 @@ namespace Farmacheck.Controllers
             var unidad = await _businessUnitApi.GetBusinessUnitAsync(model.UnidadDeNegocioId);
             model.UnidadDeNegocioNombre = unidad?.Nombre;
 
+            var permisosAsignados = await _permissionByRoleApi.GetByRolAsync(id);
+            model.Permisos = permisosAsignados?.Select(p => p.PermisoId).ToList() ?? new List<int>();
+            _permisosPorRol[id] = model.Permisos;
+
             return Json(new { success = true, data = model });
         }
 
         [HttpGet]
         public async Task<JsonResult> ListarPermisos(int id)
         {
-            _permisosPorRol.TryGetValue(id, out var asignados);
-            asignados ??= new List<int>();
-
             var permisos = await _permissionApi.GetPermissionsAsync();
             var data = permisos.Select(p => new
             {
                 p.Id,
-                p.Nombre,
-                Asignado = asignados.Contains(p.Id)
+                p.Nombre
             });
 
             return Json(new { success = true, data });

--- a/Farmacheck/Views/Rol/Index.cshtml
+++ b/Farmacheck/Views/Rol/Index.cshtml
@@ -146,12 +146,12 @@
             });
         }
 
-        function cargarPermisos(id = 0) {
+        function cargarPermisos(id = 0, asignados = []) {
             $.get('@Url.Action("ListarPermisos", "Rol")', { id }, function (r) {
                 const contenedor = $('#contenedorPermisos');
                 contenedor.empty();
                 r.data.forEach(p => {
-                    const checked = p.asignado ? 'checked' : '';
+                    const checked = asignados.includes(p.id) ? 'checked' : '';
                     contenedor.append(`
                         <div class="form-check">
                             <input class="form-check-input permiso-check" type="checkbox" value="${p.id}" id="permiso_${p.id}" ${checked}>
@@ -171,7 +171,7 @@
                     $('#estatusCheck').prop('checked', u.estatus).prop('disabled', false);
                     cargarUnidades(u.unidadDeNegocioId).then(function () {
                         $('#modalEntidad').modal('show');
-                        cargarPermisos(u.id);
+                        cargarPermisos(u.id, u.permisos || []);
                     });
                 } else {
                     showAlert(r.error || 'Error al cargar', 'error');


### PR DESCRIPTION
## Summary
- Load permissions assigned to a role using `IPermissionByRoleApiClient` in `Obtener`
- Pass selected permissions to the view so checkboxes are pre-checked
- Simplify `ListarPermisos` to return available permissions

## Testing
- `dotnet build Farmacheck/Farmacheck.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6891938d6460833180e40f96e4a0fe89