### PR TITLE
Align business structure models with API

### DIFF
--- a/Farmacheck.Application/DTOs/BusinessStructureDto.cs
+++ b/Farmacheck.Application/DTOs/BusinessStructureDto.cs
@@ -2,9 +2,16 @@ namespace Farmacheck.Application.DTOs
 {
     public class BusinessStructureDto
     {
-        public int UnidadDeNegocioId { get; set; }
-        public int MarcaId { get; set; }
-        public int SubmarcaId { get; set; }
+        public long? ClienteId { get; set; }
+        public string? Cliente { get; set; }
+        public int? MarcaId { get; set; }
+        public string? Marca { get; set; }
+        public int? SubmarcaId { get; set; }
+        public string? Submarca { get; set; }
         public int ZonaId { get; set; }
+        public string? Zona { get; set; }
+        public bool? Estatus { get; set; }
+        public DateTime? ModificadaEl { get; set; }
+        public int? UnidadDeNegocioId { get; set; }
     }
 }

--- a/Farmacheck.Application/Mappings/BusinessStructureProfile.cs
+++ b/Farmacheck.Application/Mappings/BusinessStructureProfile.cs
@@ -11,10 +11,10 @@ namespace Farmacheck.Application.Mappings
             CreateMap<BusinessStructureResponse, BusinessStructureDto>();
 
             CreateMap<BusinessStructureDto, BusinessStructureRequest>()
-                .ForMember(dest => dest.MarcaId, opt => opt.MapFrom(src => src.MarcaId))
+                .ForMember(dest => dest.MarcaId, opt => opt.MapFrom(src => src.MarcaId ?? 0))
                 .ForMember(dest => dest.SubmarcaId, opt => opt.MapFrom(src => src.SubmarcaId))
                 .ForMember(dest => dest.ZonaId, opt => opt.MapFrom(src => src.ZonaId))
-                .ForMember(dest => dest.ClienteId, opt => opt.Ignore());
+                .ForMember(dest => dest.ClienteId, opt => opt.MapFrom(src => (int)(src.ClienteId ?? 0)));
 
             CreateMap<BusinessStructureDto, UpdateBusinessStructureRequest>()
                 .IncludeBase<BusinessStructureDto, BusinessStructureRequest>();

--- a/Farmacheck.Application/Models/BusinessStructures/BusinessStructureResponse.cs
+++ b/Farmacheck.Application/Models/BusinessStructures/BusinessStructureResponse.cs
@@ -2,10 +2,14 @@ namespace Farmacheck.Application.Models.BusinessStructures
 {
     public class BusinessStructureResponse
     {
-        public long ClienteId { get; set; }
-        public int MarcaId { get; set; }
+        public long? ClienteId { get; set; }
+        public string? Cliente { get; set; }
+        public int? MarcaId { get; set; }
+        public string? Marca { get; set; }
         public int? SubmarcaId { get; set; }
+        public string? Submarca { get; set; }
         public int ZonaId { get; set; }
+        public string? Zona { get; set; }
         public bool? Estatus { get; set; }
         public DateTime? ModificadaEl { get; set; }
     }

--- a/Farmacheck.Application/Models/Customers/BusinessStructureResponse.cs
+++ b/Farmacheck.Application/Models/Customers/BusinessStructureResponse.cs
@@ -2,9 +2,15 @@ namespace Farmacheck.Application.Models.Customers
 {
     public class BusinessStructureResponse
     {
-        public int UnidadDeNegocioId { get; set; }
-        public int MarcaId { get; set; }
-        public int SubmarcaId { get; set; }
+        public long? ClienteId { get; set; }
+        public string? Cliente { get; set; }
+        public int? MarcaId { get; set; }
+        public string? Marca { get; set; }
+        public int? SubmarcaId { get; set; }
+        public string? Submarca { get; set; }
         public int ZonaId { get; set; }
+        public string? Zona { get; set; }
+        public bool? Estatus { get; set; }
+        public DateTime? ModificadaEl { get; set; }
     }
 }

--- a/Farmacheck.Application/Models/Customers/CustomerResponse.cs
+++ b/Farmacheck.Application/Models/Customers/CustomerResponse.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Farmacheck.Application.Models.Customers
 {
@@ -16,6 +17,7 @@ namespace Farmacheck.Application.Models.Customers
         public bool Estatus { get; set; }
         public short RadioGps { get; set; }
         public short TipoDeClienteId { get; set; }
+        [JsonPropertyName("businessStructure")]
         public IEnumerable<BusinessStructureResponse> BusinessStructure { get; set; } = null!;
     }
 }


### PR DESCRIPTION
## Summary
- Expand BusinessStructureResponse models to include API fields such as Cliente, Marca and Zona identifiers
- Extend BusinessStructureDto and adjust AutoMapper profile to map nullable identifiers and ClienteId
- Map `businessStructure` JSON field explicitly in CustomerResponse

## Testing
- `dotnet build Farmacheck/Farmacheck.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68924d60754083319c2f42b044c12e46