### PR TITLE
refactor: consult roles via user-role client

### DIFF
--- a/Farmacheck.Application/Interfaces/IUserApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IUserApiClient.cs
@@ -7,7 +7,6 @@ namespace Farmacheck.Application.Interfaces
         Task<List<UserResponse>> GetUsersAsync();
         Task<List<UserResponse>> GetUsersByPageAsync(int page, int items);
         Task<UserResponse?> GetUserAsync(int id);
-        Task<List<UserByRoleResponse>> GetRolesByUserAsync(int usuarioId);
         Task<int> CreateAsync(UserRequest request);
         Task<bool> UpdateAsync(UpdateUserRequest request);
         Task DeleteAsync(int id);

--- a/Farmacheck.Infrastructure/Services/UsersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/UsersApiClient.cs
@@ -31,12 +31,6 @@ namespace Farmacheck.Infrastructure.Services
             return await _http.GetFromJsonAsync<UserResponse>($"api/v1/Users/{id}");
         }
 
-        public async Task<List<UserByRoleResponse>> GetRolesByUserAsync(int usuarioId)
-        {
-            return await _http.GetFromJsonAsync<List<UserByRoleResponse>>($"api/v1/Users/{usuarioId}/roles")
-                   ?? new List<UserByRoleResponse>();
-        }
-
         public async Task<int> CreateAsync(UserRequest request)
         {
             var response = await _http.PostAsJsonAsync("api/v1/Users", request);

--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -172,7 +172,7 @@ namespace Farmacheck.Controllers
         [HttpGet]
         public async Task<JsonResult> ListarRolesPorUsuario(int usuarioId)
         {
-            var apiData = await _apiClient.GetRolesByUserAsync(usuarioId);
+            var apiData = await _userByRoleApiClient.GetByUserAsync(usuarioId);
             var dtos = _mapper.Map<List<UserByRoleDto>>(apiData);
             var roles = _mapper.Map<List<UsuarioRolViewModel>>(dtos);
 


### PR DESCRIPTION
## Summary
- remove `GetRolesByUserAsync` from `IUserApiClient`
- use `IUserByRoleApiClient` in `UsuarioController` to fetch roles by user
- drop unused roles-by-user method in `UsersApiClient`

## Testing
- `dotnet build Farmacheck/Farmacheck.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from archive.ubuntu.com)*

------
https://chatgpt.com/codex/tasks/task_e_6892d0f4ddc083319a6cbd45ff152dae