### PR TITLE
Agregar edición de clientes por rol de usuario

### DIFF
--- a/Farmacheck.Application/Interfaces/ICustomersRolesUsersApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ICustomersRolesUsersApiClient.cs
@@ -6,6 +6,7 @@ namespace Farmacheck.Application.Interfaces
     public interface ICustomersRolesUsersApiClient
     {
         Task<List<CustomerRolUserResponse>> GetByCustomerAsync(long client);
+        Task<List<CustomerRolUserResponse>> GetsByUserRolAsync(int rolPorUsuarioId);
         Task<List<CustomerRolUserResponse>> GetAsync();
         Task<List<CustomerRolUserResponse>> GetPagesAsync(int page, int items);
         Task<List<CustomerRolUserResponse>> GetPagesByCustomerAsync(int page, int items, long customer);

--- a/Farmacheck.Infrastructure/Services/CustomersRolesUsersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CustomersRolesUsersApiClient.cs
@@ -21,6 +21,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<CustomerRolUserResponse>();
         }
 
+        public async Task<List<CustomerRolUserResponse>> GetsByUserRolAsync(int rolPorUsuarioId)
+        {
+            var url = $"api/v1/Customers_RolesUsers/rolPorUsuario?rolPorUsuario={rolPorUsuarioId}";
+            return await _http.GetFromJsonAsync<List<CustomerRolUserResponse>>(url)
+                   ?? new List<CustomerRolUserResponse>();
+        }
+
         public async Task<List<CustomerRolUserResponse>> GetAsync()
         {
             return await _http.GetFromJsonAsync<List<CustomerRolUserResponse>>("api/v1/Customers_RolesUsers")

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -210,6 +210,7 @@
 @section Scripts {
 
     <script>
+        let clientesSeleccionados = [];
 
         $(document).ready(function () {
             cargar();
@@ -220,6 +221,7 @@
                 cargarMarcas($(this).val());
             });
             $('#modalGestionRol').on('show.bs.modal', function () {
+                clientesSeleccionados = [];
                 cargarRolesModal();
             });
 
@@ -307,7 +309,7 @@
                                                 <td>${item.totalClientesAsignados}</td>
                                                 <td>${item.unidadDeNegocioNombre}</td>
                                                 <td class="text-center">
-                                                    <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editarRol(${item.rolPorUsuarioId})"><i class="bi bi-pencil"></i></button>
+                                                    <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editarClientesPorRolPorUsuario(${item.rolPorUsuarioId})"><i class="bi bi-pencil"></i></button>
                                                     <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminarRol(${item.rolPorUsuarioId})"><i class="bi bi-trash"></i></button>
                                                 </td>
                                             </tr>
@@ -548,6 +550,13 @@
                                 </div>
                             `);
                         });
+
+                        clientesSeleccionados.forEach(id => {
+                            $(`#cliente_${id}`).prop('checked', true);
+                        });
+                        const total = $('#contenedorClientes .cliente-check').length;
+                        const checked = $('#contenedorClientes .cliente-check:checked').length;
+                        $('#checkAllClientes').prop('checked', total > 0 && total === checked);
                     }
                 }
             });
@@ -698,8 +707,17 @@
             }
         }
 
-        function editarRol(id) {
-            console.log('Editar rol por usuario', id);
+        function editarClientesPorRolPorUsuario(id) {
+            $('#modalGestionRol').modal('show');
+            $.get('@Url.Action("ObtenerClientesPorRolPorUsuario", "Usuario")', { id }, function (r) {
+                if (r.success) {
+                    clientesSeleccionados = r.data.clienteIds || [];
+                    $('#rolSelectModal').val(r.data.rolId);
+                    $('#unidadDeNegocioSelect').val(r.data.unidadDeNegocioId).change();
+                } else {
+                    showAlert(r.error || 'Error al obtener datos', 'error');
+                }
+            });
         }
 
         function eliminarRol(id) {


### PR DESCRIPTION
## Summary
- Añade método GetsByUserRolAsync para recuperar clientes asociados a un rol por usuario.
- Integra acción ObtenerClientesPorRolPorUsuario que devuelve rol, unidad de negocio y clientes asignados.
- Actualiza vista de Usuario para precargar rol y unidad de negocio al editar y marcar clientes existentes.

## Testing
- `dotnet test Farmacheck/Farmacheck.sln` *(falló: command not found)*
- `apt-get update` *(falló: 403 Forbidden al acceder a repositorios)*

------
https://chatgpt.com/codex/tasks/task_e_6893fcd6ab8c833185f234d472c0245d