### PR TITLE
feat: preload subbrand selections in user role editor

### DIFF
--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -447,7 +447,7 @@
             });
         }
 
-        function cargarMarcas(unidadId, marcasSeleccionadas = []) {
+        function cargarMarcas(unidadId, marcasSeleccionadas = [], submarcasSeleccionadas = []) {
             const contenedor = $('#contenedorMarcas');
             const contenedorSub = $('#contenedorSubMarcas');
             contenedor.empty();
@@ -472,13 +472,13 @@
                     const checkedCount = $('#contenedorMarcas .marca-check:checked').length;
                     $('#checkAllMarcas').prop('checked', total > 0 && total === checkedCount);
                     if (marcasSeleccionadas.length > 0) {
-                        cargarSubMarcas(marcasSeleccionadas);
+                        cargarSubMarcas(marcasSeleccionadas, submarcasSeleccionadas);
                     }
                 }
             });
         }
 
-        function cargarSubMarcas(marcaIds) {
+        function cargarSubMarcas(marcaIds, submarcasSeleccionadas = []) {
             const contenedor = $('#contenedorSubMarcas');
             contenedor.empty();
             $('#checkAllSubMarcas').prop('checked', false);
@@ -493,13 +493,20 @@
                 success: function (r) {
                     if (r.success) {
                         r.data.forEach(s => {
+                            const checked = submarcasSeleccionadas.includes(s.id) ? 'checked' : '';
                             contenedor.append(`
                                 <div class="form-check">
-                                    <input class="form-check-input submarca-check" type="checkbox" value="${s.id}" id="submarca_${s.id}">
+                                    <input class="form-check-input submarca-check" type="checkbox" value="${s.id}" id="submarca_${s.id}" ${checked}>
                                     <label class="form-check-label" for="submarca_${s.id}">${s.nombre}</label>
                                 </div>
                             `);
                         });
+                        const total = $('#contenedorSubMarcas .submarca-check').length;
+                        const checkedCount = $('#contenedorSubMarcas .submarca-check:checked').length;
+                        $('#checkAllSubMarcas').prop('checked', total > 0 && total === checkedCount);
+                        if (submarcasSeleccionadas.length > 0) {
+                            cargarClientes();
+                        }
                     }
                 }
             });
@@ -721,7 +728,7 @@
                     clientesSeleccionados = r.data.clienteIds || [];
                     $('#rolSelectModal').val(r.data.rolId);
                     $('#unidadDeNegocioSelect').val(r.data.unidadDeNegocioId);
-                    cargarMarcas(r.data.unidadDeNegocioId, r.data.marcaIds || []);
+                    cargarMarcas(r.data.unidadDeNegocioId, r.data.marcaIds || [], r.data.submarcaIds || []);
                 } else {
                     showAlert(r.error || 'Error al obtener datos', 'error');
                 }


### PR DESCRIPTION
## Summary
- preload subbrands when editing user roles
- mark subbrand checkboxes and update "select all" state

## Testing
- `dotnet test Farmacheck/Farmacheck.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894150623c48331a11362c5fcf9a810