### PR TITLE
Limpiar modalGestionRol después de guardar

### DIFF
--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -398,6 +398,7 @@
                             success: function (r) {
                                 if (r.success) {
                                     showAlert('Gestión de Clientes/Rol por usuario realizada correctamente', 'success');
+                                    limpiarModalGestionRol();
                                     $('#modalGestionRol').modal('hide');
                                     $('#modalEntidad').modal('show');
                                     cargarSelectorRoles();
@@ -450,6 +451,7 @@
                     success: function (r) {
                         if (r.success) {
                             showAlert('El registro de clientes asignados a rol por usuario se realizó correctamente', 'success');
+                            limpiarModalGestionRol();
                             $('#modalGestionRol').modal('hide');
                             $('#modalEntidad').modal('show');
                             cargarSelectorRoles();
@@ -737,7 +739,7 @@
             });
         }
 
-              function limpiar() {
+        function limpiar() {
             // Reset campos de formulario
             $('#entidadId').val('');
             $('#nombre').val('');
@@ -772,6 +774,22 @@
             // // Volver a cargar opciones dinámicas si es necesario
             // cargarUnidadesNegocio();
             // cargarZonas();
+        }
+
+        function limpiarModalGestionRol() {
+            $('#idRolPorUsuario').val('');
+            $('#rolSelectModal').val('');
+            $('#unidadDeNegocioSelect').val('');
+            $('#checkAllMarcas').prop('checked', false);
+            $('#checkAllSubMarcas').prop('checked', false);
+            $('#checkAllZonas').prop('checked', false);
+            $('#checkAllClientes').prop('checked', false);
+            $('#buscarCliente').val('');
+            $('#contenedorMarcas').empty();
+            $('#contenedorSubMarcas').empty();
+            $('#contenedorClientes').empty();
+            clientesSeleccionados = [];
+            cargarZonas();
         }
 
         function agregarRolARelacion(rol, farmacia, unidadNegocio) {


### PR DESCRIPTION
## Summary
- Reinicia los campos del modal de gestión de roles tras guardar los cambios
- Agrega función `limpiarModalGestionRol` para restablecer selects, checks e inputs

## Testing
- `cd Farmacheck && dotnet build` *(falla: command not found)*
- `apt-get update` *(falla: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68944eda96408331a34fb0d53ec33ee1