### PR TITLE
Eliminar rol cliente directo

### DIFF
--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -241,6 +241,28 @@ namespace Farmacheck.Controllers
             return Json(new { success = true });
         }
 
+        [HttpPost]
+        public async Task<JsonResult> EliminarRolClienteDirecto(int id)
+        {
+            try
+            {
+                var customers = await _customersRolesUsersApiClient.GetsByUserRolAsync(id);
+                var remover = customers.Select(c => c.Id).ToList();
+
+                if (remover.Count > 0)
+                {
+                    await _customersRolesUsersApiClient.RemoveByCustomerAsync(remover, 0);
+                }
+
+                await _userByRoleApiClient.DeleteAsync(id);
+                return Json(new { success = true });
+            }
+            catch (Exception ex)
+            {
+                return Json(new { success = false, error = "Error al eliminar el rol: " + ex.Message });
+            }
+        }
+
         [HttpGet]
         public async Task<JsonResult> ObtenerClientesPorRolPorUsuario(int id)
         {

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -833,7 +833,21 @@
         function eliminarRol(id) {
             confirmAction('¿Deseas eliminar este rol?').then(function (ok) {
                 if (!ok) return;
-                console.log('Eliminar rol por usuario', id);
+
+                $.ajax({
+                    url: '@Url.Action("EliminarRolClienteDirecto", "Usuario")',
+                    type: 'POST',
+                    data: { id: id },
+                    success: function (r) {
+                        if (r.success) {
+                            showAlert('Rol eliminado correctamente', 'success');
+                            cargarSelectorRoles();
+                            $('#tablaRoles tbody').html('<tr class="text-center text-muted" id="noRolesRow"><td colspan="4">No hay roles encontrados</td></tr>');
+                        } else {
+                            showAlert(r.error || 'Error al eliminar', 'error');
+                        }
+                    }
+                });
             });
         }
     </script>


### PR DESCRIPTION
## Summary
- Implement delete of role with clients cleanup
- Wire role delete button to new controller action

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68956fdc1bb88331b14472806111fafa