### PR TITLE
Add user disable confirmation and controller delete handler

### DIFF
--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -235,10 +235,17 @@ namespace Farmacheck.Controllers
         }
 
         [HttpPost]
-        public async Task<JsonResult> Eliminar(int id)
+        public async Task<JsonResult> EliminarUsuario(int id)
         {
-            await _apiClient.DeleteAsync(id);
-            return Json(new { success = true });
+            try
+            {
+                await _apiClient.DeleteAsync(id);
+                return Json(new { success = true, message = "Usuario deshabilitado correctamente" });
+            }
+            catch (Exception ex)
+            {
+                return Json(new { success = false, error = "Error al deshabilitar el usuario: " + ex.Message });
+            }
         }
 
         [HttpPost]

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -727,13 +727,14 @@
         }
 
         function eliminar(id) {
-            confirmAction('¿Deseas eliminar este usuario?').then(function (ok) {
+            confirmAction('¿Deseas deshabilitar este usuario?').then(function (ok) {
                 if (!ok) return;
-                $.post('@Url.Action("Eliminar", "Usuario")', { id }, function (r) {
+                $.post('@Url.Action("EliminarUsuario", "Usuario")', { id }, function (r) {
                     if (r.success) {
+                        showAlert(r.message || 'Usuario deshabilitado correctamente', 'success');
                         cargar();
                     } else {
-                        showAlert(r.error || 'Error al eliminar', 'error');
+                        showAlert(r.error || 'Error al deshabilitar', 'error');
                     }
                 });
             });


### PR DESCRIPTION
## Summary
- add EliminarUsuario endpoint with response handling and success/error messages
- prompt and process user disabling on Usuarios list

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689574d4d4f88331aa2e095393e3d768