### PR TITLE
Implement pagination for brands

### DIFF
--- a/Farmacheck.Application/Interfaces/IBrandApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IBrandApiClient.cs
@@ -1,11 +1,12 @@
 ﻿using Farmacheck.Application.Models.Brands;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface IBrandApiClient
     {
         Task<List<BrandResponse>> GetBrandsAsync();
-        Task<List<BrandResponse>> GetBrandsByPageAsync(int page, int items);
+        Task<PaginatedResponse<BrandResponse>> GetBrandsByPageAsync(int page, int items);
         Task<List<BrandResponse>> GetBrandsByBusinessUnitAsync(int businessUnitId);
         Task<BrandResponse?> GetBrandAsync(int? id);
         Task<int> CreateAsync(BrandRequest request);

--- a/Farmacheck.Infrastructure/Services/BrandApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/BrandApiClient.cs
@@ -1,5 +1,7 @@
 ﻿using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Brands;
+using Farmacheck.Application.Models.Common;
+using System;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -18,11 +20,12 @@ namespace Farmacheck.Infrastructure.Services
             return await _http.GetFromJsonAsync<List<BrandResponse>>("api/v1/Brands")
                    ?? new List<BrandResponse>();
         }
-        public async Task<List<BrandResponse>> GetBrandsByPageAsync(int page, int items)
+
+        public async Task<PaginatedResponse<BrandResponse>> GetBrandsByPageAsync(int page, int items)
         {
             var url = $"api/v1/Brands/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<BrandResponse>>(url)
-                   ?? new List<BrandResponse>();
+            return await _http.GetFromJsonAsync<PaginatedResponse<BrandResponse>>(url)
+                   ?? new PaginatedResponse<BrandResponse>(Array.Empty<BrandResponse>(), 0, page, items);
         }
 
         public async Task<List<BrandResponse>> GetBrandsByBusinessUnitAsync(int businessUnitId)

--- a/Farmacheck/Views/Marca/Index.cshtml
+++ b/Farmacheck/Views/Marca/Index.cshtml
@@ -27,6 +27,15 @@
         </thead>
         <tbody></tbody>
     </table>
+    <div class="d-flex justify-content-end">
+        <nav>
+            <ul class="pagination mb-0">
+                <li class="page-item"><button class="page-link" id="btnPrev">Anterior</button></li>
+                <li class="page-item"><span class="page-link" id="lblPage"></span></li>
+                <li class="page-item"><button class="page-link" id="btnNext">Siguiente</button></li>
+            </ul>
+        </nav>
+    </div>
 </div>
 
 <div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
@@ -68,10 +77,23 @@
 @section Scripts {
     <script>
         const unidadId = @ViewBag.UnidadId;
+        var pagina = @ViewBag.Page ?? 1;
+        var pageSize = 5;
 
         $(document).ready(function () {
-            cargar();
-            
+            cargar(pagina);
+
+            $('#btnPrev').click(function () {
+                if (pagina > 1) {
+                    pagina--;
+                    cargar(pagina);
+                }
+            });
+
+            $('#btnNext').click(function () {
+                pagina++;
+                cargar(pagina);
+            });
 
             $('#btnNueva').click(function () {
                 limpiar();
@@ -113,7 +135,7 @@
                             ? 'Marca registrada correctamente'
                             : 'Marca actualizada correctamente';
                         showAlert(mensaje, 'success');
-                        cargar();
+                        cargar(pagina);
                     } else {
                         showAlert(r.error || 'Error al guardar', 'error');
                     }
@@ -136,17 +158,13 @@
             });
         }
 
-        function cargar() {
-            $.get('@Url.Action("Listar", "Marca")', { unidadId }, function (r) {
+        function cargar(pag) {
+            $.get('@Url.Action("Listar", "Marca")', { page: pag }, function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
-                    if ($.fn.DataTable.isDataTable(tabla)) {
-                        tabla.DataTable().destroy();
-                    }
-
                     const tbody = tabla.find('tbody');
                     tbody.empty();
-                    r.data.forEach(u => {
+                    r.data.items.forEach(u => {
                         tbody.append(`<tr>
                             <td>${u.id}</td>
                             <td>${u.nombre}</td>
@@ -158,13 +176,22 @@
                         </tr>`);
                     });
 
+                    if ($.fn.DataTable.isDataTable(tabla)) {
+                        tabla.DataTable().destroy();
+                    }
                     tabla.DataTable({
-                        pageLength: 5,
-                        lengthMenu: [5, 10, 25, 50, 100],
+                        paging: false,
+                        searching: true,
+                        ordering: true,
+                        info: false,
                         language: {
                             url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                         }
                     });
+
+                    $('#lblPage').text(pag);
+                    $('#btnPrev').prop('disabled', pag === 1);
+                    $('#btnNext').prop('disabled', !r.data.hasNextPage);
                 }
             });
         }
@@ -194,7 +221,7 @@
                 if (!ok) return;
                 $.post('@Url.Action("Eliminar", "Marca")', { id }, function (r) {
                     if (r.success) {
-                        cargar();
+                        cargar(pagina);
                     } else {
                         showAlert(r.error || 'Error al eliminar', 'error');
                     }


### PR DESCRIPTION
## Summary
- add paginated brand retrieval in API client
- update Marca controller to use server-side pagination
- enhance brand index view with navigation controls

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689826b9ef748331b345a63783d352ec