### PR TITLE
Fix brand pagination request to API

### DIFF
--- a/Farmacheck.Infrastructure/Services/BrandApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/BrandApiClient.cs
@@ -23,9 +23,16 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<PaginatedResponse<BrandResponse>> GetBrandsByPageAsync(int page, int items)
         {
-            var url = $"api/v1/Brands/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<PaginatedResponse<BrandResponse>>(url)
-                   ?? new PaginatedResponse<BrandResponse>(Array.Empty<BrandResponse>(), 0, page, items);
+            var serverPage = page > 0 ? page - 1 : 0;
+            var url = $"api/v1/Brands/pages?page={serverPage}&items={items}";
+            var result = await _http.GetFromJsonAsync<PaginatedResponse<BrandResponse>>(url);
+
+            if (result is null)
+            {
+                return new PaginatedResponse<BrandResponse>(Array.Empty<BrandResponse>(), 0, page, items);
+            }
+
+            return new PaginatedResponse<BrandResponse>(result.Items, result.TotalCount, result.CurrentPage + 1, result.PageSize);
         }
 
         public async Task<List<BrandResponse>> GetBrandsByBusinessUnitAsync(int businessUnitId)


### PR DESCRIPTION
## Summary
- adjust page index when requesting brands and normalize returned page number

## Testing
- `dotnet test Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689837fc2f40833192af044f187263d4