### PR TITLE
Standardize paginated API responses

### DIFF
--- a/Farmacheck.Application/Interfaces/IBusinessStructureApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IBusinessStructureApiClient.cs
@@ -1,11 +1,12 @@
 using Farmacheck.Application.Models.BusinessStructures;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface IBusinessStructureApiClient
     {
         Task<List<BusinessStructureResponse>> GetBusinessStructuresAsync();
-        Task<List<BusinessStructureResponse>> GetBusinessStructuresByPageAsync(int page, int items);
+        Task<PaginatedResponse<BusinessStructureResponse>> GetBusinessStructuresByPageAsync(int page, int items);
         Task<BusinessStructureResponse?> GetBusinessStructureAsync(int id);
         Task<IEnumerable<BusinessStructureResponse>?> GetBusinessStructureByCustomerAsync(long customerId);
         Task<int> CreateAsync(BusinessStructureRequest request);

--- a/Farmacheck.Application/Interfaces/ICategoryByQuestionnaireApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ICategoryByQuestionnaireApiClient.cs
@@ -1,11 +1,12 @@
 using Farmacheck.Application.Models.CategoriesByQuestionnaires;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface ICategoryByQuestionnaireApiClient
     {
         Task<List<CategoryByQuestionnaireResponse>> GetCategoriesAsync();
-        Task<List<CategoryByQuestionnaireResponse>> GetCategoriesByPageAsync(int page, int items);
+        Task<PaginatedResponse<CategoryByQuestionnaireResponse>> GetCategoriesByPageAsync(int page, int items);
         Task<CategoryByQuestionnaireResponse?> GetCategoryAsync(byte id);
         Task<byte> CreateAsync(CategoryByQuestionnaireRequest request);
         Task<bool> UpdateAsync(UpdateCategoryByQuestionnaireRequest request);

--- a/Farmacheck.Application/Interfaces/IClientesAsignadosArolPorUsuariosApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IClientesAsignadosArolPorUsuariosApiClient.cs
@@ -1,11 +1,12 @@
 using Farmacheck.Application.Models.ClientesAsignadosArolPorUsuarios;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface IClientesAsignadosArolPorUsuariosApiClient
     {
         Task<List<ClientesAsignadosArolPorUsuarioResponse>> GetClientesAsignadosAsync();
-        Task<List<ClientesAsignadosArolPorUsuarioResponse>> GetClientesAsignadosByPageAsync(int page, int items);
+        Task<PaginatedResponse<ClientesAsignadosArolPorUsuarioResponse>> GetClientesAsignadosByPageAsync(int page, int items);
         Task<ClientesAsignadosArolPorUsuarioResponse?> GetClienteAsignadoAsync(int id);
         Task<List<RolPorUsuarioClientesAsignadosResponse>> GetCountByRolPorUsuarioAsync(List<int> rolPorUsuarioIds, int usuarioId);
         Task<int> CreateAsync(ClientesAsignadosArolPorUsuarioRequest request);

--- a/Farmacheck.Application/Interfaces/ICustomerTypesApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ICustomerTypesApiClient.cs
@@ -1,11 +1,12 @@
 using Farmacheck.Application.Models.CustomerTypes;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface ICustomerTypesApiClient
     {
         Task<List<CustomerTypeResponse>> GetCustomerTypesAsync();
-        Task<List<CustomerTypeResponse>> GetCustomerTypesByPageAsync(int page, int items);
+        Task<PaginatedResponse<CustomerTypeResponse>> GetCustomerTypesByPageAsync(int page, int items);
         Task<CustomerTypeResponse?> GetCustomerTypeAsync(int id);
         Task<int> CreateAsync(CustomerTypeRequest request);
         Task<bool> UpdateAsync(UpdateCustomerTypeRequest request);

--- a/Farmacheck.Application/Interfaces/IPermissionApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IPermissionApiClient.cs
@@ -1,11 +1,12 @@
 using Farmacheck.Application.Models.Permissions;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface IPermissionApiClient
     {
         Task<List<PermissionResponse>> GetPermissionsAsync();
-        Task<List<PermissionResponse>> GetPermissionsByPageAsync(int page, int items);
+        Task<PaginatedResponse<PermissionResponse>> GetPermissionsByPageAsync(int page, int items);
         Task<PermissionResponse?> GetPermissionAsync(int id);
         Task<int> CreateAsync(PermissionRequest request);
         Task<bool> UpdateAsync(UpdatePermissionRequest request);

--- a/Farmacheck.Application/Interfaces/IPermissionByRoleApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IPermissionByRoleApiClient.cs
@@ -1,11 +1,12 @@
 using Farmacheck.Application.Models.PermissionsByRoles;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface IPermissionByRoleApiClient
     {
         Task<List<PermissionByRoleResponse>> GetPermissionsByRolesAsync();
-        Task<List<PermissionByRoleResponse>> GetPermissionsByRolesByPageAsync(int page, int items);
+        Task<PaginatedResponse<PermissionByRoleResponse>> GetPermissionsByRolesByPageAsync(int page, int items);
         Task<PermissionByRoleResponse?> GetPermissionByRoleAsync(int id);
         Task<List<PermissionByRoleResponse>> GetByRolAsync(int rolId);
         Task<int> CreateAsync(PermissionByRoleRequest request);

--- a/Farmacheck.Application/Interfaces/IRoleApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IRoleApiClient.cs
@@ -1,11 +1,12 @@
 using Farmacheck.Application.Models.Roles;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface IRoleApiClient
     {
         Task<List<RoleResponse>> GetRolesAsync();
-        Task<List<RoleResponse>> GetRolesByPageAsync(int page, int items);
+        Task<PaginatedResponse<RoleResponse>> GetRolesByPageAsync(int page, int items);
         Task<RoleResponse?> GetRoleAsync(byte id);
         Task<int> CreateAsync(RoleRequest request);
         Task<bool> UpdateAsync(UpdateRoleRequest request);

--- a/Farmacheck.Application/Interfaces/ISubbrandApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ISubbrandApiClient.cs
@@ -1,12 +1,13 @@
 ﻿
 using Farmacheck.Application.Models.SubBrands;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface ISubbrandApiClient
     {
         Task<List<SubbrandResponse>> GetSubbrandsAsync();
-        Task<List<SubbrandResponse>> GetSubbrandsByPageAsync(int page, int items);
+        Task<PaginatedResponse<SubbrandResponse>> GetSubbrandsByPageAsync(int page, int items);
         Task<List<SubbrandResponse>> GetSubbrandsByBrandsAsync(List<int> brands);
         Task<SubbrandResponse?> GetSubbrandAsync(int id);
         Task<int> CreateAsync(SubbrandRequest request);

--- a/Farmacheck.Application/Interfaces/IUserApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IUserApiClient.cs
@@ -1,11 +1,12 @@
 using Farmacheck.Application.Models.Users;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface IUserApiClient
     {
         Task<List<UserResponse>> GetUsersAsync();
-        Task<List<UserResponse>> GetUsersByPageAsync(int page, int items);
+        Task<PaginatedResponse<UserResponse>> GetUsersByPageAsync(int page, int items);
         Task<UserResponse?> GetUserAsync(int id);
         Task<int> CreateAsync(UserRequest request);
         Task<bool> UpdateAsync(UpdateUserRequest request);

--- a/Farmacheck.Application/Interfaces/IUserByRoleApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IUserByRoleApiClient.cs
@@ -1,11 +1,12 @@
 using Farmacheck.Application.Models.Users;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface IUserByRoleApiClient
     {
         Task<List<UserByRoleResponse>> GetUsersByRolesAsync();
-        Task<List<UserByRoleResponse>> GetUsersByRolesByPageAsync(int page, int items);
+        Task<PaginatedResponse<UserByRoleResponse>> GetUsersByRolesByPageAsync(int page, int items);
         Task<UserByRoleResponse?> GetUserByRoleAsync(int id);
         Task<List<RelUserByRoleResponse>> GetByUserAsync(int usuarioId);
         Task<int> CreateAsync(UserByRoleRequest request);

--- a/Farmacheck.Application/Interfaces/IZoneApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IZoneApiClient.cs
@@ -1,11 +1,12 @@
 using Farmacheck.Application.Models.Zones;
+using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Application.Interfaces
 {
     public interface IZoneApiClient
     {
         Task<List<ZoneResponse>> GetZonesAsync();
-        Task<List<ZoneResponse>> GetZonesByPageAsync(int page, int items);
+        Task<PaginatedResponse<ZoneResponse>> GetZonesByPageAsync(int page, int items);
         Task<ZoneResponse?> GetZoneAsync(int id);
         Task<int> CreateAsync(ZoneRequest request);
         Task<bool> UpdateAsync(UpdateZoneRequest request);

--- a/Farmacheck.Infrastructure/Services/BrandApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/BrandApiClient.cs
@@ -24,8 +24,10 @@ namespace Farmacheck.Infrastructure.Services
         public async Task<PaginatedResponse<BrandResponse>> GetBrandsByPageAsync(int page, int items)
         {
             var url = $"api/v1/Brands/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<PaginatedResponse<BrandResponse>>(url)
-                   ?? new PaginatedResponse<BrandResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<BrandResponse>>(url)
+                      ?? new PaginatedResponse<BrandResponse>();
+
+            return res;
         }
 
         public async Task<List<BrandResponse>> GetBrandsByBusinessUnitAsync(int businessUnitId)

--- a/Farmacheck.Infrastructure/Services/BusinessStructureApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/BusinessStructureApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.BusinessStructures;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -19,11 +20,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<BusinessStructureResponse>();
         }
 
-        public async Task<List<BusinessStructureResponse>> GetBusinessStructuresByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<BusinessStructureResponse>> GetBusinessStructuresByPageAsync(int page, int items)
         {
             var url = $"api/v1/BusinessStructure/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<BusinessStructureResponse>>(url)
-                   ?? new List<BusinessStructureResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<BusinessStructureResponse>>(url)
+                      ?? new PaginatedResponse<BusinessStructureResponse>();
+
+            return res;
         }
 
         public async Task<BusinessStructureResponse?> GetBusinessStructureAsync(int id)

--- a/Farmacheck.Infrastructure/Services/BusinessUnitApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/BusinessUnitApiClient.cs
@@ -23,8 +23,10 @@ namespace Farmacheck.Infrastructure.Services
         public async Task<PaginatedResponse<BusinessUnitResponse>> GetBusinessUnitsByPageAsync(int page, int items)
         {
             var url = $"api/v1/BusinessUnits/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<PaginatedResponse<BusinessUnitResponse>>(url)
-                ?? new PaginatedResponse<BusinessUnitResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<BusinessUnitResponse>>(url)
+                      ?? new PaginatedResponse<BusinessUnitResponse>();
+
+            return res;
         }
 
         public async Task<BusinessUnitResponse?> GetBusinessUnitAsync(int id)

--- a/Farmacheck.Infrastructure/Services/CategoryByQuestionnaireApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CategoryByQuestionnaireApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.CategoriesByQuestionnaires;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -19,11 +20,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<CategoryByQuestionnaireResponse>();
         }
 
-        public async Task<List<CategoryByQuestionnaireResponse>> GetCategoriesByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<CategoryByQuestionnaireResponse>> GetCategoriesByPageAsync(int page, int items)
         {
             var url = $"api/v1/CategoriesByChecklists/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<CategoryByQuestionnaireResponse>>(url)
-                   ?? new List<CategoryByQuestionnaireResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<CategoryByQuestionnaireResponse>>(url)
+                      ?? new PaginatedResponse<CategoryByQuestionnaireResponse>();
+
+            return res;
         }
 
         public async Task<CategoryByQuestionnaireResponse?> GetCategoryAsync(byte id)
@@ -56,7 +59,7 @@ namespace Farmacheck.Infrastructure.Services
             catch (Exception ex)
             {
                 // Manejo general de errores
-                Console.WriteLine($"Ocurrió un error inesperado al eliminar el recurso con ID {id}: {ex.Message}");
+                Console.WriteLine($"OcurriÃ³ un error inesperado al eliminar el recurso con ID {id}: {ex.Message}");
                 throw;
             }
         }

--- a/Farmacheck.Infrastructure/Services/ClientesAsignadosArolPorUsuariosApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/ClientesAsignadosArolPorUsuariosApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.ClientesAsignadosArolPorUsuarios;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 using System.Linq;
 
@@ -20,11 +21,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<ClientesAsignadosArolPorUsuarioResponse>();
         }
 
-        public async Task<List<ClientesAsignadosArolPorUsuarioResponse>> GetClientesAsignadosByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<ClientesAsignadosArolPorUsuarioResponse>> GetClientesAsignadosByPageAsync(int page, int items)
         {
             var url = $"api/v1/ClientesAsignadosArolPorUsuarios/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<ClientesAsignadosArolPorUsuarioResponse>>(url)
-                   ?? new List<ClientesAsignadosArolPorUsuarioResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<ClientesAsignadosArolPorUsuarioResponse>>(url)
+                      ?? new PaginatedResponse<ClientesAsignadosArolPorUsuarioResponse>();
+
+            return res;
         }
 
         public async Task<ClientesAsignadosArolPorUsuarioResponse?> GetClienteAsignadoAsync(int id)

--- a/Farmacheck.Infrastructure/Services/CustomerTypesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CustomerTypesApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.CustomerTypes;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -19,11 +20,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<CustomerTypeResponse>();
         }
 
-        public async Task<List<CustomerTypeResponse>> GetCustomerTypesByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<CustomerTypeResponse>> GetCustomerTypesByPageAsync(int page, int items)
         {
             var url = $"api/v1/CustomerTypes/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<CustomerTypeResponse>>(url)
-                   ?? new List<CustomerTypeResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<CustomerTypeResponse>>(url)
+                      ?? new PaginatedResponse<CustomerTypeResponse>();
+
+            return res;
         }
 
         public async Task<CustomerTypeResponse?> GetCustomerTypeAsync(int id)

--- a/Farmacheck.Infrastructure/Services/HierarchyByRolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/HierarchyByRolesApiClient.cs
@@ -23,8 +23,10 @@ namespace Farmacheck.Infrastructure.Services
         public async Task<PaginatedResponse<HierarchyByRoleResponse>> GetByPageAsync(int page, int items)
         {
             var url = $"api/v1/HierarchyByRole/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<PaginatedResponse<HierarchyByRoleResponse>>(url)
-                   ?? new PaginatedResponse<HierarchyByRoleResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<HierarchyByRoleResponse>>(url)
+                      ?? new PaginatedResponse<HierarchyByRoleResponse>();
+
+            return res;
         }
 
         public async Task<HierarchyByRoleResponse?> GetAsync(int id)

--- a/Farmacheck.Infrastructure/Services/PermissionByRolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/PermissionByRolesApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.PermissionsByRoles;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -19,11 +20,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<PermissionByRoleResponse>();
         }
 
-        public async Task<List<PermissionByRoleResponse>> GetPermissionsByRolesByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<PermissionByRoleResponse>> GetPermissionsByRolesByPageAsync(int page, int items)
         {
             var url = $"api/v1/PermissionsByRoles/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<PermissionByRoleResponse>>(url)
-                   ?? new List<PermissionByRoleResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<PermissionByRoleResponse>>(url)
+                      ?? new PaginatedResponse<PermissionByRoleResponse>();
+
+            return res;
         }
 
         public async Task<PermissionByRoleResponse?> GetPermissionByRoleAsync(int id)

--- a/Farmacheck.Infrastructure/Services/PermissionsApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/PermissionsApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Permissions;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -19,11 +20,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<PermissionResponse>();
         }
 
-        public async Task<List<PermissionResponse>> GetPermissionsByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<PermissionResponse>> GetPermissionsByPageAsync(int page, int items)
         {
             var url = $"api/v1/Permissions/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<PermissionResponse>>(url)
-                   ?? new List<PermissionResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<PermissionResponse>>(url)
+                      ?? new PaginatedResponse<PermissionResponse>();
+
+            return res;
         }
 
         public async Task<PermissionResponse?> GetPermissionAsync(int id)

--- a/Farmacheck.Infrastructure/Services/RolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/RolesApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Roles;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -19,11 +20,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<RoleResponse>();
         }
 
-        public async Task<List<RoleResponse>> GetRolesByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<RoleResponse>> GetRolesByPageAsync(int page, int items)
         {
             var url = $"api/v1/Roles/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<RoleResponse>>(url)
-                   ?? new List<RoleResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<RoleResponse>>(url)
+                      ?? new PaginatedResponse<RoleResponse>();
+
+            return res;
         }
 
         public async Task<RoleResponse?> GetRoleAsync(byte id)

--- a/Farmacheck.Infrastructure/Services/SubbrandApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/SubbrandApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.SubBrands;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 using System.Linq;
 
@@ -20,10 +21,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<SubbrandResponse>();
         }
 
-        public async Task<List<SubbrandResponse>> GetSubbrandsByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<SubbrandResponse>> GetSubbrandsByPageAsync(int page, int items)
         {
-            return await _http.GetFromJsonAsync<List<SubbrandResponse>>($"api/v1/Subbrands/pages?page={page}&items={items}")
-                   ?? new List<SubbrandResponse>();
+            var url = $"api/v1/Subbrands/pages?page={page}&items={items}";
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<SubbrandResponse>>(url)
+                      ?? new PaginatedResponse<SubbrandResponse>();
+
+            return res;
         }
         public async Task<List<SubbrandResponse>> GetSubbrandsByBrandsAsync(List<int> brands)
         {

--- a/Farmacheck.Infrastructure/Services/UsersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/UsersApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Users;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -19,11 +20,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<UserResponse>();
         }
 
-        public async Task<List<UserResponse>> GetUsersByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<UserResponse>> GetUsersByPageAsync(int page, int items)
         {
             var url = $"api/v1/Users/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<UserResponse>>(url)
-                   ?? new List<UserResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<UserResponse>>(url)
+                      ?? new PaginatedResponse<UserResponse>();
+
+            return res;
         }
 
         public async Task<UserResponse?> GetUserAsync(int id)

--- a/Farmacheck.Infrastructure/Services/UsersByRolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/UsersByRolesApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Users;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -19,11 +20,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<UserByRoleResponse>();
         }
 
-        public async Task<List<UserByRoleResponse>> GetUsersByRolesByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<UserByRoleResponse>> GetUsersByRolesByPageAsync(int page, int items)
         {
             var url = $"api/v1/UsersByRoles/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<UserByRoleResponse>>(url)
-                   ?? new List<UserByRoleResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<UserByRoleResponse>>(url)
+                      ?? new PaginatedResponse<UserByRoleResponse>();
+
+            return res;
         }
 
         public async Task<UserByRoleResponse?> GetUserByRoleAsync(int id)

--- a/Farmacheck.Infrastructure/Services/ZonesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/ZonesApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Zones;
+using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -19,11 +20,13 @@ namespace Farmacheck.Infrastructure.Services
                    ?? new List<ZoneResponse>();
         }
 
-        public async Task<List<ZoneResponse>> GetZonesByPageAsync(int page, int items)
+        public async Task<PaginatedResponse<ZoneResponse>> GetZonesByPageAsync(int page, int items)
         {
             var url = $"api/v1/Zones/pages?page={page}&items={items}";
-            return await _http.GetFromJsonAsync<List<ZoneResponse>>(url)
-                   ?? new List<ZoneResponse>();
+            var res = await _http.GetFromJsonAsync<PaginatedResponse<ZoneResponse>>(url)
+                      ?? new PaginatedResponse<ZoneResponse>();
+
+            return res;
         }
 
         public async Task<ZoneResponse?> GetZoneAsync(int id)


### PR DESCRIPTION
## Summary
- return `PaginatedResponse<T>` in all `ByPageAsync` service clients and interfaces
- align implementation pattern with `CustomersApiClient`

## Testing
- `dotnet build Farmacheck/Farmacheck.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a5bf2879083318c62b54a12e80675