### PR TITLE
Implement subbrand pagination

### DIFF
--- a/Farmacheck/Views/SubMarca/Index.cshtml
+++ b/Farmacheck/Views/SubMarca/Index.cshtml
@@ -1,5 +1,5 @@
 
-@model List<Farmacheck.Models.SubMarca>
+@model Farmacheck.Application.Models.Common.PaginatedResponse<Farmacheck.Models.SubMarca>
 @{
     ViewData["Title"] = "SubMarcas";
 }
@@ -26,8 +26,27 @@
                 <th style="width:20%;" class="text-center"></th>
             </tr>
         </thead>
-        <tbody></tbody>
+        <tbody>
+        @foreach (var u in Model.Items)
+        {
+            <tr>
+                <td>@u.Id</td>
+                <td>@u.Nombre</td>
+                <td>@(u.MarcaNombre ?? "")</td>
+                <td>@(u.Estatus == true ? "Activo" : "Inactivo")</td>
+                <td class="text-center">
+                    <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@u.Id)"><i class="bi bi-pencil"></i></button>
+                    <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(@u.Id)"><i class="bi bi-trash"></i></button>
+                </td>
+            </tr>
+        }
+        </tbody>
     </table>
+    <div class="d-flex justify-content-end">
+        <nav>
+            <ul class="pagination mb-0" id="paginador"></ul>
+        </nav>
+    </div>
 </div>
 
 <div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
@@ -63,11 +82,24 @@
 @section Scripts {
     <script>
         const marcaId = @ViewBag.MarcaId;
+        var pagina = @Model.CurrentPage;
+        var pageSize = @Model.PageSize;
 
         $(document).ready(function () {
-            cargar();
             cargarMarcas();
-            
+
+            $('#tablaDatos').DataTable({
+                paging: false,
+                searching: true,
+                ordering: true,
+                info: false,
+                language: {
+                    url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
+                }
+            });
+
+            renderPagination({ totalPages: @Model.TotalPages, hasNextPage: @Model.HasNextPage.ToString().ToLower(), hasPreviousPage: @Model.HasPreviousPage.ToString().ToLower() });
+
             $('#btnNueva').click(function () {
                 limpiar();
                 $('#modalTitulo').text('Nueva submarca');
@@ -75,42 +107,41 @@
             });
 
             $('#btnGuardar').click(function () {
-            const id = $('#entidadId').val() || 0;
+                const id = $('#entidadId').val() || 0;
 
-            const datos = {
-                Id: id,
-                Nombre: $('#nombre').val(),
-                MarcaId: $('#marcaSelect').val(),
-                Estatus: $('#estatusCheck').is(':checked')
-            };
+                const datos = {
+                    Id: id,
+                    Nombre: $('#nombre').val(),
+                    MarcaId: $('#marcaSelect').val(),
+                    Estatus: $('#estatusCheck').is(':checked')
+                };
 
-            $.ajax({
-                url: '@Url.Action("Guardar", "SubMarca")',
-                method: 'POST',
-                contentType: 'application/json',
-                data: JSON.stringify(datos),
-                success: function (r) {
-                    if (r.success) {
-                        $('#modalEntidad').modal('hide');
-                        cargar();
+                $.ajax({
+                    url: '@Url.Action("Guardar", "SubMarca")',
+                    method: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify(datos),
+                    success: function (r) {
+                        if (r.success) {
+                            $('#modalEntidad').modal('hide');
+                            cargar(pagina);
 
-                        // Mostrar mensaje según sea agregar o actualizar
-                        if (parseInt(id) === 0) {
-                            showAlert('Submarca registrada correctamente', 'success');
+                            if (parseInt(id) === 0) {
+                                showAlert('Submarca registrada correctamente', 'success');
+                            } else {
+                                showAlert('Submarca actualizada correctamente', 'success');
+                            }
                         } else {
-                            showAlert('Submarca actualizada correctamente', 'success');
+                            showAlert(r.error || 'Error al guardar', 'error');
                         }
-                    } else {
-                        showAlert(r.error || 'Error al guardar', 'error');
                     }
-                }
+                });
             });
-        });
 
         });
 
-        function cargar() {
-            $.get('@Url.Action("Listar", "SubMarca")', function (r) {
+        function cargar(pag) {
+            $.get('@Url.Action("Listar", "SubMarca")', { page: pag }, function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
                     if ($.fn.DataTable.isDataTable(tabla)) {
@@ -119,7 +150,7 @@
 
                     const tbody = tabla.find('tbody');
                     tbody.empty();
-                    r.data.forEach(u => {
+                    r.data.items.forEach(u => {
                         tbody.append(`<tr>
                             <td>${u.id}</td>
                             <td>${u.nombre}</td>
@@ -133,22 +164,82 @@
                     });
 
                     tabla.DataTable({
-                        pageLength: 5,
-                        lengthMenu: [5, 10, 25, 50, 100],
+                        paging: false,
+                        searching: true,
+                        ordering: true,
+                        info: false,
                         language: {
                             url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                         }
                     });
+
+                    pagina = pag;
+                    renderPagination(r.data);
+                }
+            });
+        }
+
+        function renderPagination(data) {
+            const pagContainer = $('#paginador');
+            pagContainer.empty();
+
+            if (data.totalPages <= 0) return;
+
+            const total = data.totalPages;
+            const current = pagina;
+
+            const addPage = (p) => {
+                const active = p === current ? 'active' : '';
+                pagContainer.append(`<li class="page-item ${active}"><a class="page-link" href="#" data-page="${p}">${p}</a></li>`);
+            };
+
+            pagContainer.append(`<li class="page-item ${data.hasPreviousPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current - 1}">Anterior</a></li>`);
+
+            if (total <= 5) {
+                for (let i = 1; i <= total; i++) {
+                    addPage(i);
+                }
+            } else {
+                if (current <= 3) {
+                    for (let i = 1; i <= 4; i++) {
+                        addPage(i);
+                    }
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    addPage(total);
+                } else if (current >= total - 2) {
+                    addPage(1);
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    for (let i = total - 3; i <= total; i++) {
+                        addPage(i);
+                    }
+                } else {
+                    addPage(1);
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    for (let i = current - 1; i <= current + 1; i++) {
+                        addPage(i);
+                    }
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    addPage(total);
+                }
+            }
+
+            pagContainer.append(`<li class="page-item ${data.hasNextPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current + 1}">Siguiente</a></li>`);
+
+            pagContainer.find('a').off('click').on('click', function (e) {
+                e.preventDefault();
+                const p = parseInt($(this).data('page'));
+                if (!isNaN(p) && p > 0 && p !== current && p <= total) {
+                    cargar(p);
                 }
             });
         }
 
         function cargarMarcas() {
-            $.get('@Url.Action("Listar", "Marca")', function (r) {
+            $.get('@Url.Action("Listar", "Marca")', { page: 1 }, function (r) {
                 if (r.success) {
                     const select = $('#marcaSelect');
                     select.empty();
-                    r.data.forEach(m => select.append(`<option value="${m.id}">${m.nombre}</option>`));
+                    r.data.items.forEach(m => select.append(`<option value="${m.id}">${m.nombre}</option>`));
                     if (marcaId) {
                         select.val(marcaId);
                     }
@@ -177,7 +268,7 @@
                 if (!ok) return;
                 $.post('@Url.Action("Eliminar", "SubMarca")', { id }, function (r) {
                     if (r.success) {
-                        cargar();
+                        cargar(pagina);
                     } else {
                         showAlert(r.error || 'Error al eliminar', 'error');
                     }


### PR DESCRIPTION
## Summary
- paginate subbrand list using `GetSubbrandsByPageAsync`
- update subbrand index view to render `PaginatedResponse` and add client-side page navigation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ad29833f08331adceb963ee0f9882