### PR TITLE
feat: add pagination to zones

### DIFF
--- a/Farmacheck/Views/Zona/Index.cshtml
+++ b/Farmacheck/Views/Zona/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@model List<Farmacheck.Models.ZonaViewModel>
+@model Farmacheck.Application.Models.Common.PaginatedResponse<Farmacheck.Models.ZonaViewModel>
 @{
     ViewData["Title"] = "Zonas";
 }
@@ -24,8 +24,26 @@
                 <th style="width:20%;" class="text-center"></th>
             </tr>
         </thead>
-        <tbody></tbody>
+        <tbody>
+        @foreach (var u in Model.Items)
+        {
+            <tr>
+                <td>@u.Id</td>
+                <td>@u.Nombre</td>
+                <td>@(u.Estatus ? "Activo" : "Inactivo")</td>
+                <td class="text-center">
+                    <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@u.Id)"><i class="bi bi-pencil"></i></button>
+                    <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(@u.Id)"><i class="bi bi-trash"></i></button>
+                </td>
+            </tr>
+        }
+        </tbody>
     </table>
+    <div class="d-flex justify-content-end">
+        <nav>
+            <ul class="pagination mb-0" id="paginador"></ul>
+        </nav>
+    </div>
 </div>
 
 <div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
@@ -56,8 +74,21 @@
 
 @section Scripts {
     <script>
+        var pagina = @Model.CurrentPage;
+        var pageSize = @Model.PageSize;
+
         $(document).ready(function () {
-            cargar();
+            $('#tablaDatos').DataTable({
+                paging: false,
+                searching: true,
+                ordering: true,
+                info: false,
+                language: {
+                    url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
+                }
+            });
+
+            renderPagination({ totalPages: @Model.TotalPages, hasNextPage: @Model.HasNextPage.ToString().ToLower(), hasPreviousPage: @Model.HasPreviousPage.ToString().ToLower() });
 
             $('#btnNueva').click(function () {
                 limpiar();
@@ -85,7 +116,7 @@
                                 ? 'Zona registrada correctamente'
                                 : 'Zona actualizada correctamente';
                             showAlert(mensaje, 'success');
-                            cargar();
+                            cargar(pagina);
                         } else {
                             showAlert(r.error || 'Error al guardar', 'error');
                         }
@@ -94,8 +125,8 @@
             });
         });
 
-        function cargar() {
-            $.get('@Url.Action("Listar", "Zona")', function (r) {
+        function cargar(pag) {
+            $.get('@Url.Action("Listar", "Zona")', { page: pag }, function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
                     if ($.fn.DataTable.isDataTable(tabla)) {
@@ -104,7 +135,7 @@
 
                     const tbody = tabla.find('tbody');
                     tbody.empty();
-                    r.data.forEach(u => {
+                    r.data.items.forEach(u => {
                         tbody.append(`<tr>
                             <td>${u.id}</td>
                             <td>${u.nombre}</td>
@@ -117,12 +148,72 @@
                     });
 
                     tabla.DataTable({
-                        pageLength: 5,
-                        lengthMenu: [5, 10, 25, 50, 100],
+                        paging: false,
+                        searching: true,
+                        ordering: true,
+                        info: false,
                         language: {
                             url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                         }
                     });
+
+                    pagina = pag;
+                    renderPagination(r.data);
+                }
+            });
+        }
+
+        function renderPagination(data) {
+            const pagContainer = $('#paginador');
+            pagContainer.empty();
+
+            if (data.totalPages <= 0) return;
+
+            const total = data.totalPages;
+            const current = pagina;
+
+            const addPage = (p) => {
+                const active = p === current ? 'active' : '';
+                pagContainer.append(`<li class="page-item ${active}"><a class="page-link" href="#" data-page="${p}">${p}</a></li>`);
+            };
+
+            pagContainer.append(`<li class="page-item ${data.hasPreviousPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current - 1}">Anterior</a></li>`);
+
+            if (total <= 5) {
+                for (let i = 1; i <= total; i++) {
+                    addPage(i);
+                }
+            } else {
+                if (current <= 3) {
+                    for (let i = 1; i <= 4; i++) {
+                        addPage(i);
+                    }
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    addPage(total);
+                } else if (current >= total - 2) {
+                    addPage(1);
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    for (let i = total - 3; i <= total; i++) {
+                        addPage(i);
+                    }
+                } else {
+                    addPage(1);
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    for (let i = current - 1; i <= current + 1; i++) {
+                        addPage(i);
+                    }
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    addPage(total);
+                }
+            }
+
+            pagContainer.append(`<li class="page-item ${data.hasNextPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current + 1}">Siguiente</a></li>`);
+
+            pagContainer.find('a').off('click').on('click', function (e) {
+                e.preventDefault();
+                const p = parseInt($(this).data('page'));
+                if (!isNaN(p) && p > 0 && p !== current && p <= total) {
+                    cargar(p);
                 }
             });
         }
@@ -147,7 +238,7 @@
                 if (!ok) return;
                 $.post('@Url.Action("Eliminar", "Zona")', { id }, function (r) {
                     if (r.success) {
-                        cargar();
+                        cargar(pagina);
                     } else {
                         showAlert(r.error || 'Error al eliminar', 'error');
                     }
@@ -162,3 +253,4 @@
         }
     </script>
 }
+


### PR DESCRIPTION
## Summary
- implement server-side pagination in ZonaController using `GetZonesByPageAsync`
- update Zona Index view to support paginated response and client-side navigation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ad57658448331956206c0e646bddf