### PR TITLE
feat: add brand report download

### DIFF
--- a/Farmacheck.Application/Interfaces/IBrandApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IBrandApiClient.cs
@@ -12,6 +12,7 @@ namespace Farmacheck.Application.Interfaces
         Task<int> CreateAsync(BrandRequest request);
         Task<bool> UpdateAsync(UpdateBrandRequest request);
         Task DeleteAsync(int id);
+        Task<string> GetReport();
 
 
     }

--- a/Farmacheck.Infrastructure/Services/BrandApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/BrandApiClient.cs
@@ -64,5 +64,12 @@ namespace Farmacheck.Infrastructure.Services
             var response = await _http.DeleteAsync($"api/v1/Brands/{id}");
             response.EnsureSuccessStatusCode();
         }
+
+        public async Task<string> GetReport()
+        {
+            var response = await _http.GetAsync("api/v1/Brands/report");
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
     }
 }

--- a/Farmacheck/Controllers/MarcaController.cs
+++ b/Farmacheck/Controllers/MarcaController.cs
@@ -157,6 +157,14 @@ namespace Farmacheck.Controllers
             return Json(new { success = true });
         }
 
+        [HttpGet]
+        public async Task<IActionResult> DescargarReporte()
+        {
+            var base64 = await _apiClient.GetReport();
+            var bytes = Convert.FromBase64String(base64);
+            return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "ReporteMarcas.xlsx");
+        }
+
         private async Task<PaginatedResponse<MarcaViewModel>> ObtenerMarcasAsync(int page, int items)
         {
             var apiData = await _apiClient.GetBrandsByPageAsync(page, items);

--- a/Farmacheck/Views/Marca/Index.cshtml
+++ b/Farmacheck/Views/Marca/Index.cshtml
@@ -12,9 +12,14 @@
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h4 class="text-dark">Marcas</h4>
-        <button id="btnNueva" class="btn" style="background-color:#00ab8e; color:white;">
-            <i class="bi bi-plus-circle"></i> Nueva marca
-        </button>
+        <div>
+            <button id="btnDescargar" class="btn btn-secondary me-2">
+                <i class="bi bi-download"></i> Descargar
+            </button>
+            <button id="btnNueva" class="btn" style="background-color:#00ab8e; color:white;">
+                <i class="bi bi-plus-circle"></i> Nueva marca
+            </button>
+        </div>
     </div>
     <table class="table table-bordered custom-table" id="tablaDatos">
         <thead>
@@ -109,6 +114,10 @@
                 $('#modalTitulo').text('Nueva marca');
                 $('#estatusCheck').prop('checked', true);
                 $('#modalEntidad').modal('show');
+            });
+
+            $('#btnDescargar').click(function () {
+                descargarReporte();
             });
 
             $('#logotipoArchivo').change(function () {
@@ -259,6 +268,20 @@
                     cargar(p);
                 }
             });
+        }
+
+        function descargarReporte() {
+            fetch('@Url.Action("DescargarReporte", "Marca")')
+                .then(r => r.blob())
+                .then(blob => {
+                    const url = window.URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = 'ReporteMarcas.xlsx';
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                });
         }
 
         function editar(id) {


### PR DESCRIPTION
## Summary
- extend brand API client with report endpoint
- allow Marca controller to download Excel report
- add download button and script on Marca index view

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c0d8e81988331aa5c54182a249088