### PR TITLE
feat: add pagination to business unit list

### DIFF
--- a/Farmacheck/Controllers/UnidadDeNegocioController.cs
+++ b/Farmacheck/Controllers/UnidadDeNegocioController.cs
@@ -27,16 +27,47 @@ namespace Farmacheck.Controllers
 
         public async Task<IActionResult> Index(int page = 1)
         {
-            var result = await ObtenerUnidadesAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetBusinessUnitsByPageAsync(page, _itemsPerPage);
+
+            var dtos = _mapper.Map<List<BusinessUnitDto>>(apiData.Items);
+            var items = _mapper.Map<List<UnidadDeNegocio>>(dtos);
+
+            var result = new PaginatedResponse<UnidadDeNegocio>
+            {
+                Items = items,
+                TotalCount = apiData.TotalCount,
+                CurrentPage = apiData.CurrentPage,
+                PageSize = apiData.PageSize,
+                TotalPages = apiData.TotalPages,
+                HasNextPage = apiData.HasNextPage,
+                HasPreviousPage = apiData.HasPreviousPage
+            };
+
             ViewBag.Page = page;
             ViewBag.HasMore = result.HasNextPage;
-            return View(result.Items.ToList());
+
+            return View(result);
         }
 
         [HttpGet]
         public async Task<JsonResult> Listar(int page = 1)
         {
-            var result = await ObtenerUnidadesAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetBusinessUnitsByPageAsync(page, _itemsPerPage);
+
+            var dtos = _mapper.Map<List<BusinessUnitDto>>(apiData.Items);
+            var items = _mapper.Map<List<UnidadDeNegocio>>(dtos);
+
+            var result = new PaginatedResponse<UnidadDeNegocio>
+            {
+                Items = items,
+                TotalCount = apiData.TotalCount,
+                CurrentPage = apiData.CurrentPage,
+                PageSize = apiData.PageSize,
+                TotalPages = apiData.TotalPages,
+                HasNextPage = apiData.HasNextPage,
+                HasPreviousPage = apiData.HasPreviousPage
+            };
+
             return Json(new { success = true, data = result });
         }
 
@@ -104,14 +135,6 @@ namespace Farmacheck.Controllers
             var base64 = await _apiClient.GetReport();
             var bytes = Convert.FromBase64String(base64);
             return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "ReporteUnidades.xlsx");
-        }
-
-        private async Task<PaginatedResponse<UnidadDeNegocio>> ObtenerUnidadesAsync(int page, int items)
-        {
-            var apiData = await _apiClient.GetBusinessUnitsByPageAsync(page, items);
-            var dtos = _mapper.Map<List<BusinessUnitDto>>(apiData.Items);
-            var unidades = _mapper.Map<List<UnidadDeNegocio>>(dtos);
-            return new PaginatedResponse<UnidadDeNegocio>();
         }
     }
 }

--- a/Farmacheck/Views/UnidadDeNegocio/Index.cshtml
+++ b/Farmacheck/Views/UnidadDeNegocio/Index.cshtml
@@ -1,4 +1,4 @@
-@model List<Farmacheck.Models.UnidadDeNegocio>
+@model Farmacheck.Application.Models.Common.PaginatedResponse<Farmacheck.Models.UnidadDeNegocio>
 @{
     ViewData["Title"] = "Unidades de negocio";
 }
@@ -32,15 +32,26 @@
                 <th style="width:20%;" class="text-center"></th>
             </tr>
         </thead>
-        <tbody></tbody>
+        <tbody>
+        @foreach (var u in Model.Items)
+        {
+            <tr>
+                <td>@u.Id</td>
+                <td>@u.Nombre</td>
+                <td>@u.Rfc</td>
+                <td>@u.Direccion</td>
+                <td>@(u.Estatus ? "Activo" : "Inactivo")</td>
+                <td class="text-center">
+                    <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@u.Id)"><i class="bi bi-pencil"></i></button>
+                    <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(@u.Id)"><i class="bi bi-trash"></i></button>
+                </td>
+            </tr>
+        }
+        </tbody>
     </table>
     <div class="d-flex justify-content-end">
         <nav>
-            <ul class="pagination mb-0">
-                <li class="page-item"><button class="page-link" id="btnPrev">Anterior</button></li>
-                <li class="page-item"><span class="page-link" id="lblPage"></span></li>
-                <li class="page-item"><button class="page-link" id="btnNext">Siguiente</button></li>
-            </ul>
+            <ul class="pagination mb-0" id="paginador"></ul>
         </nav>
     </div>
 </div>
@@ -86,23 +97,21 @@
 
 @section Scripts {
     <script>
-        var pagina = @ViewBag.Page ?? 1;
-        var pageSize = 5;
+        var pagina = @Model.CurrentPage;
+        var pageSize = @Model.PageSize;
 
         $(document).ready(function () {
-            cargar(pagina);
-
-            $('#btnPrev').click(function () {
-                if (pagina > 1) {
-                    pagina--;
-                    cargar(pagina);
+            $('#tablaDatos').DataTable({
+                paging: false,
+                searching: true,
+                ordering: true,
+                info: false,
+                language: {
+                    url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                 }
             });
 
-            $('#btnNext').click(function () {
-                pagina++;
-                cargar(pagina);
-            });
+            renderPagination({ totalPages: @Model.TotalPages, hasNextPage: @Model.HasNextPage.ToString().ToLower(), hasPreviousPage: @Model.HasPreviousPage.ToString().ToLower() });
 
             $('#btnNueva').click(function () {
                 limpiar();
@@ -157,8 +166,8 @@
 
         });
 
-        function cargar(pagina) {
-            $.get('@Url.Action("Listar", "UnidadDeNegocio")', { page: pagina }, function (r) {
+        function cargar(pag) {
+            $.get('@Url.Action("Listar", "UnidadDeNegocio")', { page: pag }, function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
                     if ($.fn.DataTable.isDataTable(tabla)) {
@@ -191,9 +200,63 @@
                         }
                     });
 
-                    $('#lblPage').text(pagina);
-                    $('#btnPrev').prop('disabled', pagina === 1);
-                    $('#btnNext').prop('disabled', !r.data.hasNextPage);
+                    pagina = pag;
+                    renderPagination(r.data);
+                }
+            });
+        }
+
+        function renderPagination(data) {
+            const pagContainer = $('#paginador');
+            pagContainer.empty();
+
+            if (data.totalPages <= 0) return;
+
+            const total = data.totalPages;
+            const current = pagina;
+
+            const addPage = (p) => {
+                const active = p === current ? 'active' : '';
+                pagContainer.append(`<li class="page-item ${active}"><a class="page-link" href="#" data-page="${p}">${p}</a></li>`);
+            };
+
+            pagContainer.append(`<li class="page-item ${data.hasPreviousPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current - 1}">Anterior</a></li>`);
+
+            if (total <= 5) {
+                for (let i = 1; i <= total; i++) {
+                    addPage(i);
+                }
+            } else {
+                if (current <= 3) {
+                    for (let i = 1; i <= 4; i++) {
+                        addPage(i);
+                    }
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    addPage(total);
+                } else if (current >= total - 2) {
+                    addPage(1);
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    for (let i = total - 3; i <= total; i++) {
+                        addPage(i);
+                    }
+                } else {
+                    addPage(1);
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    for (let i = current - 1; i <= current + 1; i++) {
+                        addPage(i);
+                    }
+                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+                    addPage(total);
+                }
+            }
+
+            pagContainer.append(`<li class="page-item ${data.hasNextPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current + 1}">Siguiente</a></li>`);
+
+            pagContainer.find('a').off('click').on('click', function (e) {
+                e.preventDefault();
+                const p = parseInt($(this).data('page'));
+                if (!isNaN(p) && p > 0 && p !== current && p <= total) {
+                    cargar(p);
                 }
             });
         }


### PR DESCRIPTION
## Summary
- add full pagination support to business unit controller
- render business units with paginated response and dynamic client-side paging

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c137055c88331874d539131417427