### PR TITLE
Revert pagination back end

### DIFF
--- a/Farmacheck/Controllers/ClienteController.cs
+++ b/Farmacheck/Controllers/ClienteController.cs
@@ -9,7 +9,6 @@ using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Customers;
 using Farmacheck.Application.DTOs;
 using Farmacheck.Application.Models.BusinessStructures;
-using Farmacheck.Application.Models.Common;
 
 namespace Farmacheck.Controllers
 {
@@ -22,7 +21,6 @@ namespace Farmacheck.Controllers
         private readonly IMapper _mapper;
         private readonly IBrandApiClient _ibrand;
         private readonly IBusinessUnitApiClient _businessUnitApiClient;
-        private const int _itemsPerPage = 5;
 
         public ClienteController(
             ICustomersApiClient apiClient,
@@ -42,51 +40,27 @@ namespace Farmacheck.Controllers
             _businessUnitApiClient = businessUnitApiClient;
         }
 
-        public async Task<IActionResult> Index(int page = 1)
+        public async Task<IActionResult> Index()
         {
-            var apiData = await _apiClient.GetCustomersByPageAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetCustomersAsync();
 
             // Map first to DTOs and then to the ViewModel to avoid missing configuration
-            var dtos = _mapper.Map<List<CustomerDto>>(apiData.Items);
+            var dtos = _mapper.Map<List<CustomerDto>>(apiData);
             var items = _mapper.Map<List<ClienteEstructuraViewModel>>(dtos);
 
-            var result = new PaginatedResponse<ClienteEstructuraViewModel>
-            {
-                Items = items,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            ViewBag.Page = page;
-            ViewBag.HasMore = result.HasNextPage;
-            return View(result);
+            return View(items);
         }
 
         [HttpGet]
-        public async Task<JsonResult> Listar(int page = 1)
+        public async Task<JsonResult> Listar()
         {
-            var apiData = await _apiClient.GetCustomersByPageAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetCustomersAsync();
 
             // Map first to DTOs and then to the ViewModel to avoid missing configuration
-            var dtos = _mapper.Map<List<CustomerDto>>(apiData.Items);
+            var dtos = _mapper.Map<List<CustomerDto>>(apiData);
             var items = _mapper.Map<List<ClienteEstructuraViewModel>>(dtos);
 
-            var result = new PaginatedResponse<ClienteEstructuraViewModel>
-            {
-                Items = items,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            return Json(new { success = true, data = result });
+            return Json(new { success = true, data = items });
         }
 
         [HttpGet]
@@ -171,15 +145,6 @@ namespace Farmacheck.Controllers
             await _apiClient.DeleteAsync(id);
             await _businessStructureApi.DeleteAsync(id);
             return Json(new { success = true });
-        }
-
-
-        private async Task<PaginatedResponse<ClienteEstructuraViewModel>> ObtenerClientesAsync(int page, int items)
-        {
-            var apiData = await _apiClient.GetCustomersByPageAsync(page, items);
-            var dtos = _mapper.Map<List<CustomerDto>>(apiData.Items);
-            var clientes = _mapper.Map<List<ClienteEstructuraViewModel>>(dtos);
-            return new PaginatedResponse<ClienteEstructuraViewModel>();
         }
 
 

--- a/Farmacheck/Controllers/SubMarcaController.cs
+++ b/Farmacheck/Controllers/SubMarcaController.cs
@@ -17,7 +17,6 @@ namespace Farmacheck.Controllers
         private readonly ISubbrandApiClient _subbrandApi;
         private readonly IBrandApiClient _brandApi;
         private readonly IMapper _mapper;
-        private const int _itemsPerPage = 5;
 
         public SubMarcaController(ISubbrandApiClient subbrandApi, IBrandApiClient brandApi, IMapper mapper)
         {
@@ -26,12 +25,12 @@ namespace Farmacheck.Controllers
             _mapper = mapper;
         }
 
-        public async Task<IActionResult> Index(int marcaId, int page = 1)
+        public async Task<IActionResult> Index(int marcaId = 0)
         {
             ViewBag.MarcaId = marcaId;
 
-            var apiData = await _subbrandApi.GetSubbrandsByPageAsync(page, _itemsPerPage);
-            var dtos = _mapper.Map<List<SubmarcaDto>>(apiData.Items);
+            var apiData = await _subbrandApi.GetSubbrandsAsync();
+            var dtos = _mapper.Map<List<SubmarcaDto>>(apiData);
             var lista = _mapper.Map<List<SubMarca>>(dtos);
 
             var brands = await _brandApi.GetBrandsAsync();
@@ -41,28 +40,14 @@ namespace Farmacheck.Controllers
                 s.MarcaNombre = b?.Nombre;
             }
 
-            var result = new PaginatedResponse<SubMarca>
-            {
-                Items = lista,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            ViewBag.Page = page;
-            ViewBag.HasMore = result.HasNextPage;
-
-            return View(result);
+            return View(lista);
         }
 
         [HttpGet]
-        public async Task<JsonResult> Listar(int page = 1)
+        public async Task<JsonResult> Listar()
         {
-            var apiData = await _subbrandApi.GetSubbrandsByPageAsync(page, _itemsPerPage);
-            var dtos = _mapper.Map<List<SubmarcaDto>>(apiData.Items);
+            var apiData = await _subbrandApi.GetSubbrandsAsync();
+            var dtos = _mapper.Map<List<SubmarcaDto>>(apiData);
             var lista = _mapper.Map<List<SubMarca>>(dtos);
 
             var brands = await _brandApi.GetBrandsAsync();
@@ -72,18 +57,7 @@ namespace Farmacheck.Controllers
                 s.MarcaNombre = b?.Nombre;
             }
 
-            var result = new PaginatedResponse<SubMarca>
-            {
-                Items = lista,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            return Json(new { success = true, data = result });
+            return Json(new { success = true, data = lista });
         }
 
         [HttpGet]

--- a/Farmacheck/Controllers/UnidadDeNegocioController.cs
+++ b/Farmacheck/Controllers/UnidadDeNegocioController.cs
@@ -17,7 +17,6 @@ namespace Farmacheck.Controllers
     {
         private readonly IBusinessUnitApiClient _apiClient;
         private readonly IMapper _mapper;
-        private const int _itemsPerPage = 5;
 
         public UnidadDeNegocioController(IBusinessUnitApiClient apiClient, IMapper mapper)
         {
@@ -25,50 +24,25 @@ namespace Farmacheck.Controllers
             _mapper = mapper;
         }
 
-        public async Task<IActionResult> Index(int page = 1)
+        public async Task<IActionResult> Index()
         {
-            var apiData = await _apiClient.GetBusinessUnitsByPageAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetBusinessUnitsAsync();
 
-            var dtos = _mapper.Map<List<BusinessUnitDto>>(apiData.Items);
+            var dtos = _mapper.Map<List<BusinessUnitDto>>(apiData);
             var items = _mapper.Map<List<UnidadDeNegocio>>(dtos);
 
-            var result = new PaginatedResponse<UnidadDeNegocio>
-            {
-                Items = items,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            ViewBag.Page = page;
-            ViewBag.HasMore = result.HasNextPage;
-
-            return View(result);
+            return View(items);
         }
 
         [HttpGet]
-        public async Task<JsonResult> Listar(int page = 1)
+        public async Task<JsonResult> Listar()
         {
-            var apiData = await _apiClient.GetBusinessUnitsByPageAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetBusinessUnitsAsync();
 
-            var dtos = _mapper.Map<List<BusinessUnitDto>>(apiData.Items);
+            var dtos = _mapper.Map<List<BusinessUnitDto>>(apiData);
             var items = _mapper.Map<List<UnidadDeNegocio>>(dtos);
 
-            var result = new PaginatedResponse<UnidadDeNegocio>
-            {
-                Items = items,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            return Json(new { success = true, data = result });
+            return Json(new { success = true, data = items });
         }
 
         [HttpGet]

--- a/Farmacheck/Controllers/ZonaController.cs
+++ b/Farmacheck/Controllers/ZonaController.cs
@@ -15,7 +15,6 @@ namespace Farmacheck.Controllers
     {
         private readonly IZoneApiClient _apiClient;
         private readonly IMapper _mapper;
-        private const int _itemsPerPage = 5;
 
         public ZonaController(IZoneApiClient apiClient, IMapper mapper)
         {
@@ -23,52 +22,27 @@ namespace Farmacheck.Controllers
             _mapper = mapper;
         }
 
-        public async Task<IActionResult> Index(int page = 1)
+        public async Task<IActionResult> Index()
         {
-            var apiData = await _apiClient.GetZonesByPageAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetZonesAsync();
 
             // Map first to DTOs and then to the ViewModel to avoid missing configuration
-            var dtos = _mapper.Map<List<ZonaDto>>(apiData.Items);
+            var dtos = _mapper.Map<List<ZonaDto>>(apiData);
             var items = _mapper.Map<List<ZonaViewModel>>(dtos);
 
-            var result = new PaginatedResponse<ZonaViewModel>
-            {
-                Items = items,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            ViewBag.Page = page;
-            ViewBag.HasMore = result.HasNextPage;
-
-            return View(result);
+            return View(items);
         }
 
         [HttpGet]
-        public async Task<JsonResult> Listar(int page = 1)
+        public async Task<JsonResult> Listar()
         {
-            var apiData = await _apiClient.GetZonesByPageAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetZonesAsync();
 
             // Map first to DTOs and then to the ViewModel to avoid missing configuration
-            var dtos = _mapper.Map<List<ZonaDto>>(apiData.Items);
+            var dtos = _mapper.Map<List<ZonaDto>>(apiData);
             var items = _mapper.Map<List<ZonaViewModel>>(dtos);
 
-            var result = new PaginatedResponse<ZonaViewModel>
-            {
-                Items = items,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            return Json(new { success = true, data = result });
+            return Json(new { success = true, data = items });
         }
 
         [HttpGet]

--- a/Farmacheck/Views/Cliente/Index.cshtml
+++ b/Farmacheck/Views/Cliente/Index.cshtml
@@ -1,4 +1,4 @@
-@model Farmacheck.Application.Models.Common.PaginatedResponse<Farmacheck.Models.ClienteEstructuraViewModel>
+@model List<Farmacheck.Models.ClienteEstructuraViewModel>
 @{
     ViewData["Title"] = "Farmacias";
 }
@@ -26,7 +26,7 @@
             </tr>
         </thead>
         <tbody>
-        @foreach (var c in Model.Items)
+        @foreach (var c in Model)
         {
             <tr>
                 <td>@c.Nombre</td>
@@ -41,11 +41,6 @@
         }
         </tbody>
     </table>
-    <div class="d-flex justify-content-end">
-        <nav>
-            <ul class="pagination mb-0" id="paginador"></ul>
-        </nav>
-    </div>
 </div>
 
 <div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
@@ -147,23 +142,20 @@
 
 @section Scripts {
     <script>
-        var pagina = @Model.CurrentPage;
-        var pageSize = @Model.PageSize;
-
         $(document).ready(function () {
             cargarCatalogos();
 
             $('#tablaDatos').DataTable({
-                paging: false,
+                paging: true,
                 searching: true,
                 ordering: true,
-                info: false,
+                info: true,
+                lengthMenu: [5, 10, 25, 50],
+                pageLength: 5,
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                 }
             });
-
-            renderPagination({ totalPages: @Model.TotalPages, hasNextPage: @Model.HasNextPage.ToString().ToLower(), hasPreviousPage: @Model.HasPreviousPage.ToString().ToLower() });
 
             $('#marcaSelect').change(function () {
                 const marcaId = $(this).val();
@@ -233,7 +225,7 @@
                     success: function (r) {
                         if (r.success) {
                             $('#modalEntidad').modal('hide');
-                            cargar(pagina);
+                            cargar();
                             const mensaje = esNuevo ? 'Farmacia agregada correctamente' : 'Farmacia actualizada correctamente';
                             showAlert(mensaje, 'success');
                         } else {
@@ -306,8 +298,8 @@
             // });
         }
 
-        function cargar(pag) {
-            $.get('@Url.Action("Listar", "Cliente")', { page: pag }, function (r) {
+        function cargar() {
+            $.get('@Url.Action("Listar", "Cliente")', function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
                     if ($.fn.DataTable.isDataTable(tabla)) {
@@ -316,7 +308,7 @@
 
                     const tbody = tabla.find('tbody');
                     tbody.empty();
-                    r.data.items.forEach(c => {
+                    r.data.forEach(c => {
                         tbody.append(`<tr>
                             <td>${c.nombre}</td>
                             <td>${c.centroDeCosto}</td>
@@ -330,72 +322,16 @@
                     });
 
                     tabla.DataTable({
-                        paging: false,
+                        paging: true,
                         searching: true,
                         ordering: true,
-                        info: false,
+                        info: true,
+                        lengthMenu: [5, 10, 25, 50],
+                        pageLength: 5,
                         language: {
                             url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                         }
                     });
-
-                    pagina = pag;
-                    renderPagination(r.data);
-                }
-            });
-        }
-
-        function renderPagination(data) {
-            const pagContainer = $('#paginador');
-            pagContainer.empty();
-
-            if (data.totalPages <= 0) return;
-
-            const total = data.totalPages;
-            const current = pagina;
-
-            const addPage = (p) => {
-                const active = p === current ? 'active' : '';
-                pagContainer.append(`<li class="page-item ${active}"><a class="page-link" href="#" data-page="${p}">${p}</a></li>`);
-            };
-
-            pagContainer.append(`<li class="page-item ${data.hasPreviousPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current - 1}">Anterior</a></li>`);
-
-            if (total <= 5) {
-                for (let i = 1; i <= total; i++) {
-                    addPage(i);
-                }
-            } else {
-                if (current <= 3) {
-                    for (let i = 1; i <= 4; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                } else if (current >= total - 2) {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = total - 3; i <= total; i++) {
-                        addPage(i);
-                    }
-                } else {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = current - 1; i <= current + 1; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                }
-            }
-
-            pagContainer.append(`<li class="page-item ${data.hasNextPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current + 1}">Siguiente</a></li>`);
-
-            pagContainer.find('a').off('click').on('click', function (e) {
-                e.preventDefault();
-                const p = parseInt($(this).data('page'));
-                if (!isNaN(p) && p > 0 && p !== current && p <= total) {
-                    cargar(p);
                 }
             });
         }
@@ -439,7 +375,7 @@
                 if (!ok) return;
                 $.post('@Url.Action("Eliminar", "Cliente")', { id }, function (r) {
                     if (r.success) {
-                        cargar(pagina);
+                        cargar();
                     } else {
                         showAlert(r.error || 'Error al eliminar', 'error');
                     }

--- a/Farmacheck/Views/SubMarca/Index.cshtml
+++ b/Farmacheck/Views/SubMarca/Index.cshtml
@@ -1,5 +1,5 @@
 
-@model Farmacheck.Application.Models.Common.PaginatedResponse<Farmacheck.Models.SubMarca>
+@model List<Farmacheck.Models.SubMarca>
 @{
     ViewData["Title"] = "SubMarcas";
 }
@@ -27,7 +27,7 @@
             </tr>
         </thead>
         <tbody>
-        @foreach (var u in Model.Items)
+        @foreach (var u in Model)
         {
             <tr>
                 <td>@u.Id</td>
@@ -42,11 +42,6 @@
         }
         </tbody>
     </table>
-    <div class="d-flex justify-content-end">
-        <nav>
-            <ul class="pagination mb-0" id="paginador"></ul>
-        </nav>
-    </div>
 </div>
 
 <div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
@@ -82,23 +77,21 @@
 @section Scripts {
     <script>
         const marcaId = @ViewBag.MarcaId;
-        var pagina = @Model.CurrentPage;
-        var pageSize = @Model.PageSize;
 
         $(document).ready(function () {
             cargarMarcas();
 
             $('#tablaDatos').DataTable({
-                paging: false,
+                paging: true,
                 searching: true,
                 ordering: true,
-                info: false,
+                info: true,
+                lengthMenu: [5, 10, 25, 50],
+                pageLength: 5,
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                 }
             });
-
-            renderPagination({ totalPages: @Model.TotalPages, hasNextPage: @Model.HasNextPage.ToString().ToLower(), hasPreviousPage: @Model.HasPreviousPage.ToString().ToLower() });
 
             $('#btnNueva').click(function () {
                 limpiar();
@@ -124,7 +117,7 @@
                     success: function (r) {
                         if (r.success) {
                             $('#modalEntidad').modal('hide');
-                            cargar(pagina);
+                            cargar();
 
                             if (parseInt(id) === 0) {
                                 showAlert('Submarca registrada correctamente', 'success');
@@ -140,8 +133,8 @@
 
         });
 
-        function cargar(pag) {
-            $.get('@Url.Action("Listar", "SubMarca")', { page: pag }, function (r) {
+        function cargar() {
+            $.get('@Url.Action("Listar", "SubMarca")', function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
                     if ($.fn.DataTable.isDataTable(tabla)) {
@@ -150,7 +143,7 @@
 
                     const tbody = tabla.find('tbody');
                     tbody.empty();
-                    r.data.items.forEach(u => {
+                    r.data.forEach(u => {
                         tbody.append(`<tr>
                             <td>${u.id}</td>
                             <td>${u.nombre}</td>
@@ -164,82 +157,26 @@
                     });
 
                     tabla.DataTable({
-                        paging: false,
+                        paging: true,
                         searching: true,
                         ordering: true,
-                        info: false,
+                        info: true,
+                        lengthMenu: [5, 10, 25, 50],
+                        pageLength: 5,
                         language: {
                             url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                         }
                     });
-
-                    pagina = pag;
-                    renderPagination(r.data);
-                }
-            });
-        }
-
-        function renderPagination(data) {
-            const pagContainer = $('#paginador');
-            pagContainer.empty();
-
-            if (data.totalPages <= 0) return;
-
-            const total = data.totalPages;
-            const current = pagina;
-
-            const addPage = (p) => {
-                const active = p === current ? 'active' : '';
-                pagContainer.append(`<li class="page-item ${active}"><a class="page-link" href="#" data-page="${p}">${p}</a></li>`);
-            };
-
-            pagContainer.append(`<li class="page-item ${data.hasPreviousPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current - 1}">Anterior</a></li>`);
-
-            if (total <= 5) {
-                for (let i = 1; i <= total; i++) {
-                    addPage(i);
-                }
-            } else {
-                if (current <= 3) {
-                    for (let i = 1; i <= 4; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                } else if (current >= total - 2) {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = total - 3; i <= total; i++) {
-                        addPage(i);
-                    }
-                } else {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = current - 1; i <= current + 1; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                }
-            }
-
-            pagContainer.append(`<li class="page-item ${data.hasNextPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current + 1}">Siguiente</a></li>`);
-
-            pagContainer.find('a').off('click').on('click', function (e) {
-                e.preventDefault();
-                const p = parseInt($(this).data('page'));
-                if (!isNaN(p) && p > 0 && p !== current && p <= total) {
-                    cargar(p);
                 }
             });
         }
 
         function cargarMarcas() {
-            $.get('@Url.Action("Listar", "Marca")', { page: 1 }, function (r) {
+            $.get('@Url.Action("Listar", "Marca")', function (r) {
                 if (r.success) {
                     const select = $('#marcaSelect');
                     select.empty();
-                    r.data.items.forEach(m => select.append(`<option value="${m.id}">${m.nombre}</option>`));
+                    r.data.forEach(m => select.append(`<option value="${m.id}">${m.nombre}</option>`));
                     if (marcaId) {
                         select.val(marcaId);
                     }
@@ -268,7 +205,7 @@
                 if (!ok) return;
                 $.post('@Url.Action("Eliminar", "SubMarca")', { id }, function (r) {
                     if (r.success) {
-                        cargar(pagina);
+                        cargar();
                     } else {
                         showAlert(r.error || 'Error al eliminar', 'error');
                     }

--- a/Farmacheck/Views/UnidadDeNegocio/Index.cshtml
+++ b/Farmacheck/Views/UnidadDeNegocio/Index.cshtml
@@ -1,4 +1,4 @@
-@model Farmacheck.Application.Models.Common.PaginatedResponse<Farmacheck.Models.UnidadDeNegocio>
+@model List<Farmacheck.Models.UnidadDeNegocio>
 @{
     ViewData["Title"] = "Unidades de negocio";
 }
@@ -33,7 +33,7 @@
             </tr>
         </thead>
         <tbody>
-        @foreach (var u in Model.Items)
+        @foreach (var u in Model)
         {
             <tr>
                 <td>@u.Id</td>
@@ -49,11 +49,6 @@
         }
         </tbody>
     </table>
-    <div class="d-flex justify-content-end">
-        <nav>
-            <ul class="pagination mb-0" id="paginador"></ul>
-        </nav>
-    </div>
 </div>
 
 <div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
@@ -97,21 +92,18 @@
 
 @section Scripts {
     <script>
-        var pagina = @Model.CurrentPage;
-        var pageSize = @Model.PageSize;
-
         $(document).ready(function () {
             $('#tablaDatos').DataTable({
-                paging: false,
+                paging: true,
                 searching: true,
                 ordering: true,
-                info: false,
+                info: true,
+                lengthMenu: [5, 10, 25, 50],
+                pageLength: 5,
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                 }
             });
-
-            renderPagination({ totalPages: @Model.TotalPages, hasNextPage: @Model.HasNextPage.ToString().ToLower(), hasPreviousPage: @Model.HasPreviousPage.ToString().ToLower() });
 
             $('#btnNueva').click(function () {
                 limpiar();
@@ -156,7 +148,7 @@
                                 ? 'Unidad insertada correctamente'
                                 : 'Unidad actualizada correctamente';
                             showAlert(mensaje, 'success');
-                            cargar(pagina);
+                            cargar();
                         } else {
                             showAlert(r.error || 'Error al guardar', 'error');
                         }
@@ -166,8 +158,8 @@
 
         });
 
-        function cargar(pag) {
-            $.get('@Url.Action("Listar", "UnidadDeNegocio")', { page: pag }, function (r) {
+        function cargar() {
+            $.get('@Url.Action("Listar", "UnidadDeNegocio")', function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
                     if ($.fn.DataTable.isDataTable(tabla)) {
@@ -176,7 +168,7 @@
 
                     const tbody = tabla.find('tbody');
                     tbody.empty();
-                    r.data.items.forEach(u => {
+                    r.data.forEach(u => {
                         tbody.append(`<tr>
                             <td>${u.id}</td>
                             <td>${u.nombre}</td>
@@ -191,72 +183,16 @@
                     });
 
                     tabla.DataTable({
-                        paging: false,
+                        paging: true,
                         searching: true,
                         ordering: true,
-                        info: false,
+                        info: true,
+                        lengthMenu: [5, 10, 25, 50],
+                        pageLength: 5,
                         language: {
                             url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                         }
                     });
-
-                    pagina = pag;
-                    renderPagination(r.data);
-                }
-            });
-        }
-
-        function renderPagination(data) {
-            const pagContainer = $('#paginador');
-            pagContainer.empty();
-
-            if (data.totalPages <= 0) return;
-
-            const total = data.totalPages;
-            const current = pagina;
-
-            const addPage = (p) => {
-                const active = p === current ? 'active' : '';
-                pagContainer.append(`<li class="page-item ${active}"><a class="page-link" href="#" data-page="${p}">${p}</a></li>`);
-            };
-
-            pagContainer.append(`<li class="page-item ${data.hasPreviousPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current - 1}">Anterior</a></li>`);
-
-            if (total <= 5) {
-                for (let i = 1; i <= total; i++) {
-                    addPage(i);
-                }
-            } else {
-                if (current <= 3) {
-                    for (let i = 1; i <= 4; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                } else if (current >= total - 2) {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = total - 3; i <= total; i++) {
-                        addPage(i);
-                    }
-                } else {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = current - 1; i <= current + 1; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                }
-            }
-
-            pagContainer.append(`<li class="page-item ${data.hasNextPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current + 1}">Siguiente</a></li>`);
-
-            pagContainer.find('a').off('click').on('click', function (e) {
-                e.preventDefault();
-                const p = parseInt($(this).data('page'));
-                if (!isNaN(p) && p > 0 && p !== current && p <= total) {
-                    cargar(p);
                 }
             });
         }
@@ -301,7 +237,7 @@
                 if (!ok) return;
                 $.post('@Url.Action("Eliminar", "UnidadDeNegocio")', { id }, function (r) {
                     if (r.success) {
-                        cargar(pagina);
+                        cargar();
                     } else {
                         showAlert(r.error || 'Error al eliminar', 'error');
                     }

--- a/Farmacheck/Views/Zona/Index.cshtml
+++ b/Farmacheck/Views/Zona/Index.cshtml
@@ -1,4 +1,4 @@
-@model Farmacheck.Application.Models.Common.PaginatedResponse<Farmacheck.Models.ZonaViewModel>
+@model List<Farmacheck.Models.ZonaViewModel>
 @{
     ViewData["Title"] = "Zonas";
 }
@@ -25,7 +25,7 @@
             </tr>
         </thead>
         <tbody>
-        @foreach (var u in Model.Items)
+        @foreach (var u in Model)
         {
             <tr>
                 <td>@u.Id</td>
@@ -39,11 +39,6 @@
         }
         </tbody>
     </table>
-    <div class="d-flex justify-content-end">
-        <nav>
-            <ul class="pagination mb-0" id="paginador"></ul>
-        </nav>
-    </div>
 </div>
 
 <div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
@@ -74,21 +69,18 @@
 
 @section Scripts {
     <script>
-        var pagina = @Model.CurrentPage;
-        var pageSize = @Model.PageSize;
-
         $(document).ready(function () {
             $('#tablaDatos').DataTable({
-                paging: false,
+                paging: true,
                 searching: true,
                 ordering: true,
-                info: false,
+                info: true,
+                lengthMenu: [5, 10, 25, 50],
+                pageLength: 5,
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                 }
             });
-
-            renderPagination({ totalPages: @Model.TotalPages, hasNextPage: @Model.HasNextPage.ToString().ToLower(), hasPreviousPage: @Model.HasPreviousPage.ToString().ToLower() });
 
             $('#btnNueva').click(function () {
                 limpiar();
@@ -116,7 +108,7 @@
                                 ? 'Zona registrada correctamente'
                                 : 'Zona actualizada correctamente';
                             showAlert(mensaje, 'success');
-                            cargar(pagina);
+                            cargar();
                         } else {
                             showAlert(r.error || 'Error al guardar', 'error');
                         }
@@ -125,8 +117,8 @@
             });
         });
 
-        function cargar(pag) {
-            $.get('@Url.Action("Listar", "Zona")', { page: pag }, function (r) {
+        function cargar() {
+            $.get('@Url.Action("Listar", "Zona")', function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
                     if ($.fn.DataTable.isDataTable(tabla)) {
@@ -135,7 +127,7 @@
 
                     const tbody = tabla.find('tbody');
                     tbody.empty();
-                    r.data.items.forEach(u => {
+                    r.data.forEach(u => {
                         tbody.append(`<tr>
                             <td>${u.id}</td>
                             <td>${u.nombre}</td>
@@ -148,72 +140,16 @@
                     });
 
                     tabla.DataTable({
-                        paging: false,
+                        paging: true,
                         searching: true,
                         ordering: true,
-                        info: false,
+                        info: true,
+                        lengthMenu: [5, 10, 25, 50],
+                        pageLength: 5,
                         language: {
                             url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                         }
                     });
-
-                    pagina = pag;
-                    renderPagination(r.data);
-                }
-            });
-        }
-
-        function renderPagination(data) {
-            const pagContainer = $('#paginador');
-            pagContainer.empty();
-
-            if (data.totalPages <= 0) return;
-
-            const total = data.totalPages;
-            const current = pagina;
-
-            const addPage = (p) => {
-                const active = p === current ? 'active' : '';
-                pagContainer.append(`<li class="page-item ${active}"><a class="page-link" href="#" data-page="${p}">${p}</a></li>`);
-            };
-
-            pagContainer.append(`<li class="page-item ${data.hasPreviousPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current - 1}">Anterior</a></li>`);
-
-            if (total <= 5) {
-                for (let i = 1; i <= total; i++) {
-                    addPage(i);
-                }
-            } else {
-                if (current <= 3) {
-                    for (let i = 1; i <= 4; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                } else if (current >= total - 2) {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = total - 3; i <= total; i++) {
-                        addPage(i);
-                    }
-                } else {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = current - 1; i <= current + 1; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                }
-            }
-
-            pagContainer.append(`<li class="page-item ${data.hasNextPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current + 1}">Siguiente</a></li>`);
-
-            pagContainer.find('a').off('click').on('click', function (e) {
-                e.preventDefault();
-                const p = parseInt($(this).data('page'));
-                if (!isNaN(p) && p > 0 && p !== current && p <= total) {
-                    cargar(p);
                 }
             });
         }
@@ -238,7 +174,7 @@
                 if (!ok) return;
                 $.post('@Url.Action("Eliminar", "Zona")', { id }, function (r) {
                     if (r.success) {
-                        cargar(pagina);
+                        cargar();
                     } else {
                         showAlert(r.error || 'Error al eliminar', 'error');
                     }


### PR DESCRIPTION
## Summary
- move Unidad de Negocio, SubMarca, Zona and Cliente controllers to return full lists without backend paging
- enable DataTables client-side pagination and page length options across related index views

## Testing
- `dotnet build Farmacheck/Farmacheck.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d599a1c088331a2691dcfdbb0d149