### PR TITLE
revert pagination back end for roles, hierarchies and users

### DIFF
--- a/Farmacheck/Controllers/JerarquiaController.cs
+++ b/Farmacheck/Controllers/JerarquiaController.cs
@@ -16,7 +16,6 @@ namespace Farmacheck.Controllers
         private readonly IHierarchyByRoleApiClient _apiClient;
         private readonly IRoleApiClient _roleApi;
         private readonly IMapper _mapper;
-        private const int _itemsPerPage = 5;
 
         public JerarquiaController(IHierarchyByRoleApiClient apiClient,
                                    IRoleApiClient roleApi,
@@ -27,53 +26,31 @@ namespace Farmacheck.Controllers
             _mapper = mapper;
         }
 
-        public async Task<IActionResult> Index(int page = 1)
+        public async Task<IActionResult> Index()
         {
-            var apiData = await _apiClient.GetByPageAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetAllAsync();
 
             // Map first to DTOs and then to the ViewModel to avoid missing configuration
-            var dtos = _mapper.Map<List<HierarchyByRoleDto>>(apiData.Items);
+            var dtos = _mapper.Map<List<HierarchyByRoleDto>>(apiData);
             var items = _mapper.Map<List<JerarquiaViewModel>>(dtos);
 
             await CompletarNombresRoles(items);
 
-            var result = new PaginatedResponse<JerarquiaViewModel>
-            {
-                Items = items,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            return View(result);
+            return View(items);
         }
 
         [HttpGet]
-        public async Task<JsonResult> Listar(int page = 1)
+        public async Task<JsonResult> Listar()
         {
-            var apiData = await _apiClient.GetByPageAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetAllAsync();
 
             // Map first to DTOs and then to the ViewModel to avoid missing configuration
-            var dtos = _mapper.Map<List<HierarchyByRoleDto>>(apiData.Items);
+            var dtos = _mapper.Map<List<HierarchyByRoleDto>>(apiData);
             var items = _mapper.Map<List<JerarquiaViewModel>>(dtos);
 
             await CompletarNombresRoles(items);
 
-            var result = new PaginatedResponse<JerarquiaViewModel>
-            {
-                Items = items,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            return Json(new { success = true, data = result });
+            return Json(new { success = true, data = items });
         }
 
         [HttpGet]

--- a/Farmacheck/Controllers/RolController.cs
+++ b/Farmacheck/Controllers/RolController.cs
@@ -22,7 +22,6 @@ namespace Farmacheck.Controllers
         private readonly IMapper _mapper;
 
         private static readonly Dictionary<int, List<int>> _permisosPorRol = new();
-        private const int _itemsPerPage = 5;
 
         public RolController(IRoleApiClient apiClient,
                              IBusinessUnitApiClient businessUnitApi,
@@ -37,12 +36,12 @@ namespace Farmacheck.Controllers
             _mapper = mapper;
         }
 
-        public async Task<IActionResult> Index(int unidadId, int page = 1)
+        public async Task<IActionResult> Index(int unidadId)
         {
             ViewBag.UnidadId = unidadId;
 
-            var apiData = await _apiClient.GetRolesByPageAsync(page, _itemsPerPage);
-            var dtos = _mapper.Map<List<RoleDto>>(apiData.Items);
+            var apiData = await _apiClient.GetRolesAsync();
+            var dtos = _mapper.Map<List<RoleDto>>(apiData);
             var roles = _mapper.Map<List<RolViewModel>>(dtos);
 
             var unidadesApi = await _businessUnitApi.GetBusinessUnitsAsync();
@@ -52,28 +51,14 @@ namespace Farmacheck.Controllers
                 r.UnidadDeNegocioNombre = u?.Nombre;
             }
 
-            var result = new PaginatedResponse<RolViewModel>
-            {
-                Items = roles,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            ViewBag.Page = page;
-            ViewBag.HasMore = result.HasNextPage;
-
-            return View(result);
+            return View(roles);
         }
 
         [HttpGet]
-        public async Task<JsonResult> Listar(int unidadId, int page = 1)
+        public async Task<JsonResult> Listar(int unidadId)
         {
-            var apiData = await _apiClient.GetRolesByPageAsync(page, _itemsPerPage);
-            var dtos = _mapper.Map<List<RoleDto>>(apiData.Items);
+            var apiData = await _apiClient.GetRolesAsync();
+            var dtos = _mapper.Map<List<RoleDto>>(apiData);
             var roles = _mapper.Map<List<RolViewModel>>(dtos);
 
             var unidadesApi = await _businessUnitApi.GetBusinessUnitsAsync();
@@ -83,18 +68,7 @@ namespace Farmacheck.Controllers
                 r.UnidadDeNegocioNombre = u?.Nombre;
             }
 
-            var result = new PaginatedResponse<RolViewModel>
-            {
-                Items = roles,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            return Json(new { success = true, data = result });
+            return Json(new { success = true, data = roles });
         }
 
         [HttpGet]

--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -27,7 +27,6 @@ namespace Farmacheck.Controllers
         private readonly ICustomersRolesUsersApiClient _customersRolesUsersApiClient;
         private readonly IRoleApiClient _roleApiClient;
         private readonly IBusinessStructureApiClient _businessStructureApiClient;
-        private const int _itemsPerPage = 5;
 
         public UsuarioController(IUserApiClient apiClient, IBrandApiClient brandApi, IMapper mapper, IBusinessUnitApiClient businessUnitApi, 
                                  ISubbrandApiClient subbrandApi, IZoneApiClient zoneApi,IClientesAsignadosArolPorUsuariosApiClient clientesAsignadosArolPorUsuariosApiClient,
@@ -48,50 +47,25 @@ namespace Farmacheck.Controllers
             _businessStructureApiClient = businessStructureApiClient;
         }
 
-        public async Task<IActionResult> Index(int page = 1)
+        public async Task<IActionResult> Index()
         {
-            var apiData = await _apiClient.GetUsersByPageAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetUsersAsync();
 
-            var dtos = _mapper.Map<List<UserDto>>(apiData.Items);
+            var dtos = _mapper.Map<List<UserDto>>(apiData);
             var usuarios = _mapper.Map<List<UsuarioViewModel>>(dtos);
 
-            var result = new PaginatedResponse<UsuarioViewModel>
-            {
-                Items = usuarios,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            ViewBag.Page = page;
-            ViewBag.HasMore = result.HasNextPage;
-
-            return View(result);
+            return View(usuarios);
         }
 
         [HttpGet]
-        public async Task<JsonResult> Listar(int page = 1)
+        public async Task<JsonResult> Listar()
         {
-            var apiData = await _apiClient.GetUsersByPageAsync(page, _itemsPerPage);
+            var apiData = await _apiClient.GetUsersAsync();
 
-            var dtos = _mapper.Map<List<UserDto>>(apiData.Items);
+            var dtos = _mapper.Map<List<UserDto>>(apiData);
             var usuarios = _mapper.Map<List<UsuarioViewModel>>(dtos);
 
-            var result = new PaginatedResponse<UsuarioViewModel>
-            {
-                Items = usuarios,
-                TotalCount = apiData.TotalCount,
-                CurrentPage = apiData.CurrentPage,
-                PageSize = apiData.PageSize,
-                TotalPages = apiData.TotalPages,
-                HasNextPage = apiData.HasNextPage,
-                HasPreviousPage = apiData.HasPreviousPage
-            };
-
-            return Json(new { success = true, data = result });
+            return Json(new { success = true, data = usuarios });
         }
 
         [HttpGet]

--- a/Farmacheck/Views/Jerarquia/Index.cshtml
+++ b/Farmacheck/Views/Jerarquia/Index.cshtml
@@ -1,4 +1,4 @@
-@model Farmacheck.Application.Models.Common.PaginatedResponse<Farmacheck.Models.JerarquiaViewModel>
+@model List<Farmacheck.Models.JerarquiaViewModel>
 @{
     ViewData["Title"] = "Jerarquía";
 }
@@ -27,7 +27,7 @@
             </tr>
         </thead>
         <tbody>
-        @foreach (var u in Model.Items)
+        @foreach (var u in Model)
         {
             <tr>
                 <td>@u.Id</td>
@@ -43,11 +43,6 @@
         }
         </tbody>
     </table>
-    <div class="d-flex justify-content-end">
-        <nav>
-            <ul class="pagination mb-0" id="paginador"></ul>
-        </nav>
-    </div>
 </div>
 
 <div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
@@ -102,23 +97,20 @@
 
 @section Scripts {
     <script>
-        var pagina = @Model.CurrentPage;
-        var pageSize = @Model.PageSize;
-
         $(document).ready(function () {
             cargarRoles();
 
             $('#tablaDatos').DataTable({
-                paging: false,
+                paging: true,
                 searching: true,
                 ordering: true,
-                info: false,
+                info: true,
+                lengthMenu: [5, 10, 25, 50],
+                pageLength: 5,
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                 }
             });
-
-            renderPagination({ totalPages: @Model.TotalPages, hasNextPage: @Model.HasNextPage.ToString().ToLower(), hasPreviousPage: @Model.HasPreviousPage.ToString().ToLower() });
 
             $('#btnNuevo').click(function () {
                 limpiar();
@@ -188,7 +180,7 @@
                             if (r.success) {
                                 $('#modalEntidad').modal('hide');
                                 showAlert('Relaciones guardadas', 'success');
-                                cargar(pagina);
+                                cargar();
                             } else {
                                 showAlert(r.error || 'Error al guardar', 'error');
                             }
@@ -212,7 +204,7 @@
                             if (r.success) {
                                 $('#modalEntidad').modal('hide');
                                 showAlert('Relación actualizada', 'success');
-                                cargar(pagina);
+                                cargar();
                             } else {
                                 showAlert(r.error || 'Error al guardar', 'error');
                             }
@@ -222,8 +214,8 @@
             });
         });
 
-        function cargar(pag) {
-            $.get('@Url.Action("Listar", "Jerarquia")', { page: pag }, function (r) {
+        function cargar() {
+            $.get('@Url.Action("Listar", "Jerarquia")', function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
                     if ($.fn.DataTable.isDataTable(tabla)) {
@@ -232,7 +224,7 @@
                     const tbody = tabla.find('tbody');
                     tbody.empty();
 
-                    r.data.items.forEach(u => {
+                    r.data.forEach(u => {
                         tbody.append(`<tr>
                             <td>${u.id}</td>
                             <td>${u.nombre}</td>
@@ -247,72 +239,16 @@
                     });
 
                     tabla.DataTable({
-                        paging: false,
+                        paging: true,
                         searching: true,
                         ordering: true,
-                        info: false,
+                        info: true,
+                        lengthMenu: [5, 10, 25, 50],
+                        pageLength: 5,
                         language: {
                             url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                         }
                     });
-
-                    pagina = pag;
-                    renderPagination(r.data);
-                }
-            });
-        }
-
-        function renderPagination(data) {
-            const pagContainer = $('#paginador');
-            pagContainer.empty();
-
-            if (data.totalPages <= 0) return;
-
-            const total = data.totalPages;
-            const current = pagina;
-
-            const addPage = (p) => {
-                const active = p === current ? 'active' : '';
-                pagContainer.append(`<li class="page-item ${active}"><a class="page-link" href="#" data-page="${p}">${p}</a></li>`);
-            };
-
-            pagContainer.append(`<li class="page-item ${data.hasPreviousPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current - 1}">Anterior</a></li>`);
-
-            if (total <= 5) {
-                for (let i = 1; i <= total; i++) {
-                    addPage(i);
-                }
-            } else {
-                if (current <= 3) {
-                    for (let i = 1; i <= 4; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                } else if (current >= total - 2) {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = total - 3; i <= total; i++) {
-                        addPage(i);
-                    }
-                } else {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = current - 1; i <= current + 1; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                }
-            }
-
-            pagContainer.append(`<li class="page-item ${data.hasNextPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current + 1}">Siguiente</a></li>`);
-
-            pagContainer.find('a').off('click').on('click', function (e) {
-                e.preventDefault();
-                const p = parseInt($(this).data('page'));
-                if (!isNaN(p) && p > 0 && p !== current && p <= total) {
-                    cargar(p);
                 }
             });
         }
@@ -365,7 +301,7 @@
                 if (!ok) return;
                 $.post('@Url.Action("Eliminar", "Jerarquia")', { id }, function (r) {
                     if (r.success) {
-                        cargar(pagina);
+                        cargar();
                     } else {
                         showAlert(r.error || 'Error al eliminar', 'error');
                     }

--- a/Farmacheck/Views/Rol/Index.cshtml
+++ b/Farmacheck/Views/Rol/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@model Farmacheck.Application.Models.Common.PaginatedResponse<Farmacheck.Models.RolViewModel>
+﻿@model List<Farmacheck.Models.RolViewModel>
 @{
     ViewData["Title"] = "Roles";
 }
@@ -28,7 +28,7 @@
             </tr>
         </thead>
         <tbody>
-        @foreach (var u in Model.Items)
+        @foreach (var u in Model)
         {
             <tr>
                 <td>@u.Id</td>
@@ -43,11 +43,6 @@
         }
         </tbody>
     </table>
-    <div class="d-flex justify-content-end">
-        <nav>
-            <ul class="pagination mb-0" id="paginador"></ul>
-        </nav>
-    </div>
 </div>
 
 <!-- MODAL -->
@@ -90,21 +85,19 @@
 @section Scripts {
     <script>
         const unidadId = @ViewBag.UnidadId;
-        var pagina = @Model.CurrentPage;
-        var pageSize = @Model.PageSize;
 
         $(document).ready(function () {
             $('#tablaDatos').DataTable({
-                paging: false,
+                paging: true,
                 searching: true,
                 ordering: true,
-                info: false,
+                info: true,
+                lengthMenu: [5, 10, 25, 50],
+                pageLength: 5,
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                 }
             });
-
-            renderPagination({ totalPages: @Model.TotalPages, hasNextPage: @Model.HasNextPage.ToString().ToLower(), hasPreviousPage: @Model.HasPreviousPage.ToString().ToLower() });
 
             $('#btnNuevo').click(function () {
                 limpiar();
@@ -140,7 +133,7 @@
                             $('#modalEntidad').modal('hide');
                             const msg = id === 0 ? 'Rol creado correctamente' : 'Rol actualizado';
                             showAlert(msg, 'success');
-                            cargar(pagina);
+                            cargar();
                         } else {
                             showAlert(r.error || 'Error al guardar', 'error');
                         }
@@ -149,8 +142,8 @@
           });
         });
 
-        function cargar(pag) {
-            $.get('@Url.Action("Listar", "Rol")', { page: pag, unidadId: unidadId }, function (r) {
+        function cargar() {
+            $.get('@Url.Action("Listar", "Rol")', { unidadId: unidadId }, function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
                     if ($.fn.DataTable.isDataTable(tabla)) {
@@ -159,7 +152,7 @@
 
                     const tbody = tabla.find('tbody');
                     tbody.empty();
-                    r.data.items.forEach(u => {
+                    r.data.forEach(u => {
                         tbody.append(`<tr>
                             <td>${u.id}</td>
                             <td>${u.nombre}</td>
@@ -173,72 +166,16 @@
                     });
 
                     tabla.DataTable({
-                        paging: false,
+                        paging: true,
                         searching: true,
                         ordering: true,
-                        info: false,
+                        info: true,
+                        lengthMenu: [5, 10, 25, 50],
+                        pageLength: 5,
                         language: {
                             url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                         }
                     });
-
-                    pagina = pag;
-                    renderPagination(r.data);
-                }
-            });
-        }
-
-        function renderPagination(data) {
-            const pagContainer = $('#paginador');
-            pagContainer.empty();
-
-            if (data.totalPages <= 0) return;
-
-            const total = data.totalPages;
-            const current = pagina;
-
-            const addPage = (p) => {
-                const active = p === current ? 'active' : '';
-                pagContainer.append(`<li class="page-item ${active}"><a class="page-link" href="#" data-page="${p}">${p}</a></li>`);
-            };
-
-            pagContainer.append(`<li class="page-item ${data.hasPreviousPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current - 1}">Anterior</a></li>`);
-
-            if (total <= 5) {
-                for (let i = 1; i <= total; i++) {
-                    addPage(i);
-                }
-            } else {
-                if (current <= 3) {
-                    for (let i = 1; i <= 4; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                } else if (current >= total - 2) {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = total - 3; i <= total; i++) {
-                        addPage(i);
-                    }
-                } else {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = current - 1; i <= current + 1; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                }
-            }
-
-            pagContainer.append(`<li class="page-item ${data.hasNextPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current + 1}">Siguiente</a></li>`);
-
-            pagContainer.find('a').off('click').on('click', function (e) {
-                e.preventDefault();
-                const p = parseInt($(this).data('page'));
-                if (!isNaN(p) && p > 0 && p !== current && p <= total) {
-                    cargar(p);
                 }
             });
         }
@@ -295,7 +232,7 @@
                 $.post('@Url.Action("Eliminar", "Rol")', { id }, function (r) {
                     if (r.success) {
                         showAlert('Rol deshabilitado correctamente', 'success');
-                        cargar(pagina);
+                        cargar();
                     } else {
                         showAlert(r.error || 'Error al eliminar', 'error');
                     }

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -1,4 +1,4 @@
-@model Farmacheck.Application.Models.Common.PaginatedResponse<Farmacheck.Models.UsuarioViewModel>
+@model List<Farmacheck.Models.UsuarioViewModel>
 @{
     ViewData["Title"] = "Usuarios";
 }
@@ -22,7 +22,7 @@
             </tr>
         </thead>
         <tbody>
-        @foreach (var u in Model.Items)
+        @foreach (var u in Model)
         {
             <tr>
                 <td>@u.Id</td>
@@ -38,11 +38,6 @@
         }
         </tbody>
     </table>
-    <div class="d-flex justify-content-end">
-        <nav>
-            <ul class="pagination mb-0" id="paginador"></ul>
-        </nav>
-    </div>
 </div>
 
 <div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
@@ -232,23 +227,21 @@
 
     <script>
         let clientesSeleccionados = [];
-        var pagina = @Model.CurrentPage;
-        var pageSize = @Model.PageSize;
         let usuarioGuardado = true;
         let rolesUsuarioIds = [];
 
         $(document).ready(function () {
             $('#tablaDatos').DataTable({
-                paging: false,
+                paging: true,
                 searching: true,
                 ordering: true,
-                info: false,
+                info: true,
+                lengthMenu: [5, 10, 25, 50],
+                pageLength: 5,
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                 }
             });
-
-            renderPagination({ totalPages: @Model.TotalPages, hasNextPage: @Model.HasNextPage.ToString().ToLower(), hasPreviousPage: @Model.HasPreviousPage.ToString().ToLower() });
 
             cargarRolesModal();
             cargarUnidadesNegocio();
@@ -402,7 +395,7 @@
                                 ? 'Usuario registrado correctamente'
                                 : 'Usuario actualizado correctamente';
                             showAlert(mensaje, 'success');
-                            cargar(pagina);
+                            cargar();
                         } else {
                             showAlert(r.error || 'Error al guardar', 'error');
                         }
@@ -747,8 +740,8 @@
             });
         }
 
-        function cargar(pag) {
-            $.get('@Url.Action("Listar", "Usuario")', { page: pag }, function (r) {
+        function cargar() {
+            $.get('@Url.Action("Listar", "Usuario")', function (r) {
                 if (r.success) {
                     const tabla = $('#tablaDatos');
                     if ($.fn.DataTable.isDataTable(tabla)) {
@@ -757,7 +750,7 @@
 
                     const tbody = tabla.find('tbody');
                     tbody.empty();
-                    r.data.items.forEach(u => {
+                    r.data.forEach(u => {
                         tbody.append(`<tr>
                             <td>${u.id}</td>
                             <td>${u.nombre} ${u.apellidoPaterno}</td>
@@ -772,72 +765,16 @@
                     });
 
                     tabla.DataTable({
-                        paging: false,
+                        paging: true,
                         searching: true,
                         ordering: true,
-                        info: false,
+                        info: true,
+                        lengthMenu: [5, 10, 25, 50],
+                        pageLength: 5,
                         language: {
                             url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
                         }
                     });
-
-                    pagina = pag;
-                    renderPagination(r.data);
-                }
-            });
-        }
-
-        function renderPagination(data) {
-            const pagContainer = $('#paginador');
-            pagContainer.empty();
-
-            if (data.totalPages <= 0) return;
-
-            const total = data.totalPages;
-            const current = pagina;
-
-            const addPage = (p) => {
-                const active = p === current ? 'active' : '';
-                pagContainer.append(`<li class="page-item ${active}"><a class="page-link" href="#" data-page="${p}">${p}</a></li>`);
-            };
-
-            pagContainer.append(`<li class="page-item ${data.hasPreviousPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current - 1}">Anterior</a></li>`);
-
-            if (total <= 5) {
-                for (let i = 1; i <= total; i++) {
-                    addPage(i);
-                }
-            } else {
-                if (current <= 3) {
-                    for (let i = 1; i <= 4; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                } else if (current >= total - 2) {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = total - 3; i <= total; i++) {
-                        addPage(i);
-                    }
-                } else {
-                    addPage(1);
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    for (let i = current - 1; i <= current + 1; i++) {
-                        addPage(i);
-                    }
-                    pagContainer.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
-                    addPage(total);
-                }
-            }
-
-            pagContainer.append(`<li class="page-item ${data.hasNextPage ? '' : 'disabled'}"><a class="page-link" href="#" data-page="${current + 1}">Siguiente</a></li>`);
-
-            pagContainer.find('a').off('click').on('click', function (e) {
-                e.preventDefault();
-                const p = parseInt($(this).data('page'));
-                if (!isNaN(p) && p > 0 && p !== current && p <= total) {
-                    cargar(p);
                 }
             });
         }
@@ -872,7 +809,7 @@
                 $.post('@Url.Action("EliminarUsuario", "Usuario")', { id }, function (r) {
                     if (r.success) {
                         showAlert(r.message || 'Usuario deshabilitado correctamente', 'success');
-                        cargar(pagina);
+                        cargar();
                     } else {
                         showAlert(r.error || 'Error al deshabilitar', 'error');
                     }


### PR DESCRIPTION
## Summary
- Switch roles, hierarchies and users controllers to return full lists instead of paginated responses
- Update associated views to leverage Bootstrap DataTables for client-side paging, sorting and item count selection

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689d5dfbfcc88331b7e82edad42b9b10