### PR TITLE
feat: add GetAll endpoints for services

### DIFF
--- a/Farmacheck.Application/Interfaces/IBusinessUnitApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IBusinessUnitApiClient.cs
@@ -5,6 +5,7 @@ namespace Farmacheck.Application.Interfaces
 {
     public interface IBusinessUnitApiClient
     {
+        Task<IEnumerable<BusinessUnitResponse>> GetAllBusinessUnitsAsync();
         Task<List<BusinessUnitResponse>> GetBusinessUnitsAsync();
         Task<PaginatedResponse<BusinessUnitResponse>> GetBusinessUnitsByPageAsync(int page, int items);
         Task<BusinessUnitResponse?> GetBusinessUnitAsync(int id);

--- a/Farmacheck.Application/Interfaces/ICategoryByQuestionnaireApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ICategoryByQuestionnaireApiClient.cs
@@ -5,6 +5,7 @@ namespace Farmacheck.Application.Interfaces
 {
     public interface ICategoryByQuestionnaireApiClient
     {
+        Task<IEnumerable<CategoryByQuestionnaireResponse>> GetAllCategoriesAsync();
         Task<List<CategoryByQuestionnaireResponse>> GetCategoriesAsync();
         Task<PaginatedResponse<CategoryByQuestionnaireResponse>> GetCategoriesByPageAsync(int page, int items);
         Task<CategoryByQuestionnaireResponse?> GetCategoryAsync(byte id);

--- a/Farmacheck.Application/Interfaces/ICustomersApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ICustomersApiClient.cs
@@ -6,6 +6,7 @@ namespace Farmacheck.Application.Interfaces
 {
     public interface ICustomersApiClient
     {
+        Task<IEnumerable<CustomerResponse>> GetAllCustomersAsync();
         Task<List<CustomerResponse>> GetCustomersAsync();
         Task<PaginatedResponse<CustomerResponse>> GetCustomersByPageAsync(int page, int items);
         Task<List<CustomerResponse>> GetCustomersByFiltersAsync(IEnumerable<int> subbrand, IEnumerable<int> zone);

--- a/Farmacheck.Application/Interfaces/IHierarchyByRoleApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IHierarchyByRoleApiClient.cs
@@ -5,6 +5,7 @@ namespace Farmacheck.Application.Interfaces
 {
     public interface IHierarchyByRoleApiClient
     {
+        Task<IEnumerable<HierarchyByRoleResponse>> GetAllHierarchyByRolesAsync();
         Task<List<HierarchyByRoleResponse>> GetAllAsync();
         Task<PaginatedResponse<HierarchyByRoleResponse>> GetByPageAsync(int page, int items);
         Task<HierarchyByRoleResponse?> GetAsync(int id);

--- a/Farmacheck.Application/Interfaces/IRoleApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IRoleApiClient.cs
@@ -5,6 +5,7 @@ namespace Farmacheck.Application.Interfaces
 {
     public interface IRoleApiClient
     {
+        Task<IEnumerable<RoleResponse>> GetAllRolesAsync();
         Task<List<RoleResponse>> GetRolesAsync();
         Task<PaginatedResponse<RoleResponse>> GetRolesByPageAsync(int page, int items);
         Task<RoleResponse?> GetRoleAsync(byte id);

--- a/Farmacheck.Application/Interfaces/ISubbrandApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ISubbrandApiClient.cs
@@ -6,6 +6,7 @@ namespace Farmacheck.Application.Interfaces
 {
     public interface ISubbrandApiClient
     {
+        Task<IEnumerable<SubbrandResponse>> GetAllSubbrandsAsync();
         Task<List<SubbrandResponse>> GetSubbrandsAsync();
         Task<PaginatedResponse<SubbrandResponse>> GetSubbrandsByPageAsync(int page, int items);
         Task<List<SubbrandResponse>> GetSubbrandsByBrandsAsync(List<int> brands);

--- a/Farmacheck.Application/Interfaces/IUserApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IUserApiClient.cs
@@ -5,6 +5,7 @@ namespace Farmacheck.Application.Interfaces
 {
     public interface IUserApiClient
     {
+        Task<IEnumerable<UserResponse>> GetAllUsersAsync();
         Task<List<UserResponse>> GetUsersAsync();
         Task<PaginatedResponse<UserResponse>> GetUsersByPageAsync(int page, int items);
         Task<UserResponse?> GetUserAsync(int id);

--- a/Farmacheck.Application/Interfaces/IZoneApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IZoneApiClient.cs
@@ -5,6 +5,7 @@ namespace Farmacheck.Application.Interfaces
 {
     public interface IZoneApiClient
     {
+        Task<IEnumerable<ZoneResponse>> GetAllZonesAsync();
         Task<List<ZoneResponse>> GetZonesAsync();
         Task<PaginatedResponse<ZoneResponse>> GetZonesByPageAsync(int page, int items);
         Task<ZoneResponse?> GetZoneAsync(int id);

--- a/Farmacheck.Infrastructure/Services/BusinessUnitApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/BusinessUnitApiClient.cs
@@ -14,6 +14,12 @@ namespace Farmacheck.Infrastructure.Services
             _http = http;
         }
 
+        public async Task<IEnumerable<BusinessUnitResponse>> GetAllBusinessUnitsAsync()
+        {
+            return await _http.GetFromJsonAsync<IEnumerable<BusinessUnitResponse>>("api/v1/BusinessUnits/all")
+                   ?? Enumerable.Empty<BusinessUnitResponse>();
+        }
+
         public async Task<List<BusinessUnitResponse>> GetBusinessUnitsAsync()
         {
             return await _http.GetFromJsonAsync<List<BusinessUnitResponse>>("api/v1/BusinessUnits")

--- a/Farmacheck.Infrastructure/Services/CategoryByQuestionnaireApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CategoryByQuestionnaireApiClient.cs
@@ -14,6 +14,12 @@ namespace Farmacheck.Infrastructure.Services
             _http = http;
         }
 
+        public async Task<IEnumerable<CategoryByQuestionnaireResponse>> GetAllCategoriesAsync()
+        {
+            return await _http.GetFromJsonAsync<IEnumerable<CategoryByQuestionnaireResponse>>("api/v1/CategoriesByChecklists/all")
+                   ?? Enumerable.Empty<CategoryByQuestionnaireResponse>();
+        }
+
         public async Task<List<CategoryByQuestionnaireResponse>> GetCategoriesAsync()
         {
             return await _http.GetFromJsonAsync<List<CategoryByQuestionnaireResponse>>("api/v1/CategoriesByChecklists")

--- a/Farmacheck.Infrastructure/Services/CustomersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CustomersApiClient.cs
@@ -18,6 +18,12 @@ namespace Farmacheck.Infrastructure.Services
             _http = http;
         }
 
+        public async Task<IEnumerable<CustomerResponse>> GetAllCustomersAsync()
+        {
+            return await _http.GetFromJsonAsync<IEnumerable<CustomerResponse>>("api/v1/Customers/all")
+                   ?? Enumerable.Empty<CustomerResponse>();
+        }
+
         public async Task<List<CustomerResponse>> GetCustomersAsync()
         {
             return await _http.GetFromJsonAsync<List<CustomerResponse>>("api/v1/Customers")

--- a/Farmacheck.Infrastructure/Services/HierarchyByRolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/HierarchyByRolesApiClient.cs
@@ -14,6 +14,12 @@ namespace Farmacheck.Infrastructure.Services
             _http = http;
         }
 
+        public async Task<IEnumerable<HierarchyByRoleResponse>> GetAllHierarchyByRolesAsync()
+        {
+            return await _http.GetFromJsonAsync<IEnumerable<HierarchyByRoleResponse>>("api/v1/HierarchyByRole/all")
+                   ?? Enumerable.Empty<HierarchyByRoleResponse>();
+        }
+
         public async Task<List<HierarchyByRoleResponse>> GetAllAsync()
         {
             return await _http.GetFromJsonAsync<List<HierarchyByRoleResponse>>("api/v1/HierarchyByRole")

--- a/Farmacheck.Infrastructure/Services/RolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/RolesApiClient.cs
@@ -14,6 +14,12 @@ namespace Farmacheck.Infrastructure.Services
             _http = http;
         }
 
+        public async Task<IEnumerable<RoleResponse>> GetAllRolesAsync()
+        {
+            return await _http.GetFromJsonAsync<IEnumerable<RoleResponse>>("api/v1/Roles/all")
+                   ?? Enumerable.Empty<RoleResponse>();
+        }
+
         public async Task<List<RoleResponse>> GetRolesAsync()
         {
             return await _http.GetFromJsonAsync<List<RoleResponse>>("api/v1/Roles")

--- a/Farmacheck.Infrastructure/Services/SubbrandApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/SubbrandApiClient.cs
@@ -15,6 +15,12 @@ namespace Farmacheck.Infrastructure.Services
             _http = http;
         }
 
+        public async Task<IEnumerable<SubbrandResponse>> GetAllSubbrandsAsync()
+        {
+            return await _http.GetFromJsonAsync<IEnumerable<SubbrandResponse>>("api/v1/Subbrands/all")
+                   ?? Enumerable.Empty<SubbrandResponse>();
+        }
+
         public async Task<List<SubbrandResponse>> GetSubbrandsAsync()
         {
             return await _http.GetFromJsonAsync<List<SubbrandResponse>>("api/v1/Subbrands")

--- a/Farmacheck.Infrastructure/Services/UsersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/UsersApiClient.cs
@@ -14,6 +14,12 @@ namespace Farmacheck.Infrastructure.Services
             _http = http;
         }
 
+        public async Task<IEnumerable<UserResponse>> GetAllUsersAsync()
+        {
+            return await _http.GetFromJsonAsync<IEnumerable<UserResponse>>("api/v1/Users/all")
+                   ?? Enumerable.Empty<UserResponse>();
+        }
+
         public async Task<List<UserResponse>> GetUsersAsync()
         {
             return await _http.GetFromJsonAsync<List<UserResponse>>("api/v1/Users")

--- a/Farmacheck.Infrastructure/Services/ZonesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/ZonesApiClient.cs
@@ -14,6 +14,12 @@ namespace Farmacheck.Infrastructure.Services
             _http = http;
         }
 
+        public async Task<IEnumerable<ZoneResponse>> GetAllZonesAsync()
+        {
+            return await _http.GetFromJsonAsync<IEnumerable<ZoneResponse>>("api/v1/Zones/all")
+                   ?? Enumerable.Empty<ZoneResponse>();
+        }
+
         public async Task<List<ZoneResponse>> GetZonesAsync()
         {
             return await _http.GetFromJsonAsync<List<ZoneResponse>>("api/v1/Zones")


### PR DESCRIPTION
## Summary
- add GetAllBusinessUnitsAsync and similar GetAll methods across interfaces
- implement corresponding GetAll API calls in service clients

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689d77d40ecc83318619fd117506f11e