### PR TITLE
feat: add client report download

### DIFF
--- a/Farmacheck.Application/Interfaces/ICustomersApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ICustomersApiClient.cs
@@ -15,5 +15,6 @@ namespace Farmacheck.Application.Interfaces
         Task<int> CreateAsync(CustomerRequest request);
         Task<bool> UpdateAsync(UpdateCustomerRequest request);
         Task DeleteAsync(int id);
+        Task<string> GetReport();
     }
 }

--- a/Farmacheck.Infrastructure/Services/CustomersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CustomersApiClient.cs
@@ -101,5 +101,12 @@ namespace Farmacheck.Infrastructure.Services
             var response = await _http.DeleteAsync($"api/v1/Customers/{id}");
             response.EnsureSuccessStatusCode();
         }
+
+        public async Task<string> GetReport()
+        {
+            var response = await _http.GetAsync("api/v1/Customers/report");
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
     }
 }

--- a/Farmacheck/Controllers/ClienteController.cs
+++ b/Farmacheck/Controllers/ClienteController.cs
@@ -9,6 +9,7 @@ using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Customers;
 using Farmacheck.Application.DTOs;
 using Farmacheck.Application.Models.BusinessStructures;
+using System;
 
 namespace Farmacheck.Controllers
 {
@@ -171,6 +172,14 @@ namespace Farmacheck.Controllers
         {
             var result = await _businessUnitApiClient.GetBusinessUnitsAsync();
             return Json(new { success = true, data = result });
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> DescargarReporte()
+        {
+            var base64 = await _apiClient.GetReport();
+            var bytes = Convert.FromBase64String(base64);
+            return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "ReporteClientes.xlsx");
         }
     }
 }

--- a/Farmacheck/Views/Cliente/Index.cshtml
+++ b/Farmacheck/Views/Cliente/Index.cshtml
@@ -11,9 +11,14 @@
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h4 class="text-dark">Farmacias</h4>
-        <button id="btnNuevo" class="btn" style="background-color:#00ab8e; color:white;">
-            <i class="bi bi-plus-circle"></i> Nueva Farmacia
-        </button>
+        <div>
+            <button id="btnDescargar" class="btn btn-secondary me-2">
+                <i class="bi bi-download"></i> Descargar
+            </button>
+            <button id="btnNuevo" class="btn" style="background-color:#00ab8e; color:white;">
+                <i class="bi bi-plus-circle"></i> Nueva Farmacia
+            </button>
+        </div>
     </div>
     <table class="table table-bordered custom-table" id="tablaDatos">
         <thead>
@@ -171,6 +176,10 @@
                 const val = $(this).val();
                 const padded = val ? val.toString().padStart(5, '0') : '';
                 $('#centroCosto').val(padded);
+            });
+
+            $('#btnDescargar').click(function () {
+                descargarReporte();
             });
 
             $('#btnNuevo').click(function () {
@@ -383,7 +392,21 @@
             });
         }
 
-                function limpiar() {
+        function descargarReporte() {
+            fetch('@Url.Action("DescargarReporte", "Cliente")')
+                .then(r => r.blob())
+                .then(blob => {
+                    const url = window.URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = 'ReporteClientes.xlsx';
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                });
+        }
+
+        function limpiar() {
             $('#clienteId').val('');
             $('#unidadNegocioSelect').val('0');
             $('#centroCosto').val('');


### PR DESCRIPTION
## Summary
- add report method to ICustomersApiClient and its implementation
- expose endpoint in ClienteController and UI to download customer report

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ed19d81ec8331a6d4efd68030ee3d