### PR TITLE
Add subbrand report download

### DIFF
--- a/Farmacheck.Application/Interfaces/ISubbrandApiClient.cs
+++ b/Farmacheck.Application/Interfaces/ISubbrandApiClient.cs
@@ -14,5 +14,6 @@ namespace Farmacheck.Application.Interfaces
         Task<int> CreateAsync(SubbrandRequest request);
         Task<bool> UpdateAsync(UpdateSubbrandRequest request);
         Task DeleteAsync(int id);
+        Task<string> GetReport();
     }
 }

--- a/Farmacheck.Infrastructure/Services/SubbrandApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/SubbrandApiClient.cs
@@ -68,5 +68,12 @@ namespace Farmacheck.Infrastructure.Services
             var response = await _http.DeleteAsync($"api/v1/Subbrands/{id}");
             response.EnsureSuccessStatusCode();
         }
+
+        public async Task<string> GetReport()
+        {
+            var response = await _http.GetAsync("api/v1/Subbrands/report");
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
     }
 }

--- a/Farmacheck/Controllers/SubMarcaController.cs
+++ b/Farmacheck/Controllers/SubMarcaController.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Farmacheck.Application.Interfaces;
 using System.Threading.Tasks;
+using System;
 using AutoMapper;
 using Farmacheck.Application.Models.SubBrands;
 using Farmacheck.Application.Models.Brands;
@@ -119,6 +120,14 @@ namespace Farmacheck.Controllers
         {
             await _subbrandApi.DeleteAsync(id);
             return Json(new { success = true });
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> DescargarReporte()
+        {
+            var base64 = await _subbrandApi.GetReport();
+            var bytes = Convert.FromBase64String(base64);
+            return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "ReporteSubmarcas.xlsx");
         }
     }
 }

--- a/Farmacheck/Views/SubMarca/Index.cshtml
+++ b/Farmacheck/Views/SubMarca/Index.cshtml
@@ -12,9 +12,14 @@
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h4 class="text-dark">Submarcas</h4>
-        <button id="btnNueva" class="btn" style="background-color:#00ab8e; color:white;">
-            <i class="bi bi-plus-circle"></i> Nueva submarca
-        </button>
+        <div>
+            <button id="btnDescargar" class="btn btn-secondary me-2">
+                <i class="bi bi-download"></i> Descargar
+            </button>
+            <button id="btnNueva" class="btn" style="background-color:#00ab8e; color:white;">
+                <i class="bi bi-plus-circle"></i> Nueva submarca
+            </button>
+        </div>
     </div>
     <table class="table table-bordered custom-table" id="tablaDatos">
         <thead>
@@ -131,7 +136,25 @@
                 });
             });
 
+            $('#btnDescargar').click(function () {
+                descargarReporte();
+            });
+
         });
+
+        function descargarReporte() {
+            fetch('@Url.Action("DescargarReporte", "SubMarca")')
+                .then(r => r.blob())
+                .then(blob => {
+                    const url = window.URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = 'ReporteSubmarcas.xlsx';
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                });
+        }
 
         function cargar() {
             $.get('@Url.Action("Listar", "SubMarca")', function (r) {


### PR DESCRIPTION
## Summary
- extend subbrand API client and interface with report endpoint
- allow SubMarca controller to download report as Excel
- add download button and script to SubMarca index view

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ed325cd9083318e5865e9aa3d76b0