### PR TITLE
Remove delete buttons from main tables

### DIFF
--- a/Farmacheck/Views/CategoriaCuestionario/Index.cshtml
+++ b/Farmacheck/Views/CategoriaCuestionario/Index.cshtml
@@ -113,7 +113,6 @@
                             <td>${u.activa ? 'Activo' : 'Inactivo'}</td>
                             <td class="text-center">
                                 <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
-                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
                             </td>
                         </tr>`);
                     });

--- a/Farmacheck/Views/Cliente/Index.cshtml
+++ b/Farmacheck/Views/Cliente/Index.cshtml
@@ -40,7 +40,6 @@
                 <td>@(c.Estatus ? "Activo" : "Inactivo")</td>
                 <td class="text-center">
                     <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@c.ClienteId)"><i class="bi bi-pencil"></i></button>
-                    <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(@c.ClienteId)"><i class="bi bi-trash"></i></button>
                 </td>
             </tr>
         }
@@ -332,7 +331,6 @@
                             <td>${c.estatus ? 'Activo' : 'Inactivo'}</td>
                             <td class="text-center">
                                 <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${c.clienteId})"><i class="bi bi-pencil"></i></button>
-                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${c.clienteId})"><i class="bi bi-trash"></i></button>
                             </td>
                         </tr>`);
                     });

--- a/Farmacheck/Views/Jerarquia/Index.cshtml
+++ b/Farmacheck/Views/Jerarquia/Index.cshtml
@@ -37,7 +37,6 @@
                 <td>@(u.Estatus ? "Activo" : "Inactivo")</td>
                 <td class="text-center">
                     <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@u.Id)"><i class="bi bi-pencil"></i></button>
-                    <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(@u.Id)"><i class="bi bi-trash"></i></button>
                 </td>
             </tr>
         }
@@ -240,7 +239,6 @@
                             <td>${u.estatus? 'Activo' : 'Inactivo'}</td>
                             <td class="text-center">
                                 <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
-                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
                             </td>
                         </tr>`);
                     });

--- a/Farmacheck/Views/Marca/Index.cshtml
+++ b/Farmacheck/Views/Marca/Index.cshtml
@@ -39,7 +39,6 @@
                 <td>@(u.Estatus == true ? "Activo" : "Inactivo")</td>
                 <td class="text-center">
                     <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@u.Id)"><i class="bi bi-pencil"></i></button>
-                    <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(@u.Id)"><i class="bi bi-trash"></i></button>
                 </td>
             </tr>
         }
@@ -195,7 +194,6 @@
                             <td>${u.estatus ? 'Activo' : 'Inactivo'}</td>
                             <td class="text-center">
                                 <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
-                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
                             </td>
                         </tr>`);
                     });

--- a/Farmacheck/Views/Rol/Index.cshtml
+++ b/Farmacheck/Views/Rol/Index.cshtml
@@ -42,7 +42,6 @@
                 <td>@(u.Estatus ? "Activo" : "Inactivo")</td>
                 <td class="text-center">
                     <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@u.Id)"><i class="bi bi-pencil"></i></button>
-                    <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(@u.Id)"><i class="bi bi-trash"></i></button>
                 </td>
             </tr>
         }
@@ -190,7 +189,6 @@
                             <td>${u.estatus ? 'Activo' : 'Inactivo'}</td>
                             <td class="text-center">
                                 <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
-                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
                             </td>
                         </tr>`);
                     });

--- a/Farmacheck/Views/SubMarca/Index.cshtml
+++ b/Farmacheck/Views/SubMarca/Index.cshtml
@@ -41,7 +41,6 @@
                 <td>@(u.Estatus == true ? "Activo" : "Inactivo")</td>
                 <td class="text-center">
                     <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@u.Id)"><i class="bi bi-pencil"></i></button>
-                    <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(@u.Id)"><i class="bi bi-trash"></i></button>
                 </td>
             </tr>
         }
@@ -183,7 +182,6 @@
                             <td>${u.estatus ? 'Activo' : 'Inactivo'}</td>
                             <td class="text-center">
                                 <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
-                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
                             </td>
                         </tr>`);
                     });

--- a/Farmacheck/Views/UnidadDeNegocio/Index.cshtml
+++ b/Farmacheck/Views/UnidadDeNegocio/Index.cshtml
@@ -43,7 +43,6 @@
                 <td>@(u.Estatus == true ? "Activo" : "Inactivo")</td>
                 <td class="text-center">
                     <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@u.Id)"><i class="bi bi-pencil"></i></button>
-                    <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(@u.Id)"><i class="bi bi-trash"></i></button>
                 </td>
             </tr>
         }
@@ -184,7 +183,6 @@
                             <td>${u.estatus ? 'Activo' : 'Inactivo'}</td>
                             <td class="text-center">
                                 <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
-                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
                             </td>
                         </tr>`);
                     });

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -32,7 +32,6 @@
                 <td>@(u.Estatus ? "Activo" : "Inactivo")</td>
                 <td class="text-center">
                     <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@u.Id)"><i class="bi bi-pencil"></i></button>
-                    <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(@u.Id)"><i class="bi bi-trash"></i></button>
                 </td>
             </tr>
         }
@@ -732,7 +731,6 @@
                                         <td>${item.unidadDeNegocioNombre}</td>
                                         <td class="text-center">
                                             <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editarClientesPorRolPorUsuario(${item.rolPorUsuarioId})"><i class="bi bi-pencil"></i></button>
-                                            <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminarRol(${item.rolPorUsuarioId})"><i class="bi bi-trash"></i></button>
                                         </td>
                                     </tr>
                                 `);
@@ -766,7 +764,6 @@
                             <td>${u.estatus ? 'Activo' : 'Inactivo'}</td>
                             <td class="text-center">
                                 <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
-                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
                             </td>
                         </tr>`);
                     });

--- a/Farmacheck/Views/Zona/Index.cshtml
+++ b/Farmacheck/Views/Zona/Index.cshtml
@@ -38,7 +38,6 @@
                 <td>@(u.Estatus == true ? "Activo" : "Inactivo")</td>                    
                 <td class="text-center">
                     <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@u.Id)"><i class="bi bi-pencil"></i></button>
-                    <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(@u.Id)"><i class="bi bi-trash"></i></button>
                 </td>
             </tr>
         }
@@ -164,7 +163,6 @@
                             <td>${u.estatus ? 'Activo' : 'Inactivo'}</td>
                             <td class="text-center">
                                 <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
-                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
                             </td>
                         </tr>`);
                     });


### PR DESCRIPTION
## Summary
- remove delete buttons from main data tables in UnidadDeNegocio, Marca, SubMarca, Zona, Cliente, CategoriaCuestionario, Rol, Jerarquia, and Usuario views

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: dotnet not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68a40fbd5374833184cd25a666337fd6