### PR TITLE
Load zones after subbrand selection using business structure filters

### DIFF
--- a/Farmacheck.Application/Interfaces/IBusinessStructureApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IBusinessStructureApiClient.cs
@@ -1,5 +1,6 @@
 using Farmacheck.Application.Models.BusinessStructures;
 using Farmacheck.Application.Models.Common;
+using System.Collections.Generic;
 
 namespace Farmacheck.Application.Interfaces
 {
@@ -8,6 +9,10 @@ namespace Farmacheck.Application.Interfaces
         Task<List<BusinessStructureResponse>> GetBusinessStructuresAsync();
         Task<PaginatedResponse<BusinessStructureResponse>> GetBusinessStructuresByPageAsync(int page, int items);
         Task<BusinessStructureResponse?> GetBusinessStructureAsync(int id);
+        Task<List<BusinessStructureResponse>> GetBusinessStructuresByFiltersAsync(
+            IEnumerable<int>? brand,
+            IEnumerable<int>? subbrand,
+            IEnumerable<int>? zone);
         Task<IEnumerable<BusinessStructureResponse>?> GetBusinessStructureByCustomerAsync(long customerId);
         Task<int> CreateAsync(BusinessStructureRequest request);
         Task<bool> UpdateAsync(UpdateBusinessStructureRequest request);

--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -20,7 +20,6 @@ namespace Farmacheck.Controllers
         private readonly IMapper _mapper;
         private readonly IBusinessUnitApiClient _businessUnitApi;
         private readonly ISubbrandApiClient _subbrandApi;
-        private readonly IZoneApiClient _zoneApi;
         private readonly IClientesAsignadosArolPorUsuariosApiClient _clientesAsignadosArolPorUsuariosApiClient;
         private readonly ICustomersApiClient _customersApi;
         private readonly IUserByRoleApiClient _userByRoleApiClient;
@@ -29,7 +28,7 @@ namespace Farmacheck.Controllers
         private readonly IBusinessStructureApiClient _businessStructureApiClient;
 
         public UsuarioController(IUserApiClient apiClient, IBrandApiClient brandApi, IMapper mapper, IBusinessUnitApiClient businessUnitApi, 
-                                 ISubbrandApiClient subbrandApi, IZoneApiClient zoneApi,IClientesAsignadosArolPorUsuariosApiClient clientesAsignadosArolPorUsuariosApiClient,
+                                 ISubbrandApiClient subbrandApi, IClientesAsignadosArolPorUsuariosApiClient clientesAsignadosArolPorUsuariosApiClient,
                                  ICustomersApiClient customersApi, IUserByRoleApiClient userByRoleApiClient, ICustomersRolesUsersApiClient customersRolesUsersApiClient,
                                  IRoleApiClient roleApiClient, IBusinessStructureApiClient businessStructureApiClient)
         {
@@ -38,7 +37,6 @@ namespace Farmacheck.Controllers
             _mapper = mapper;
             _businessUnitApi = businessUnitApi;
             _subbrandApi = subbrandApi;
-            _zoneApi = zoneApi;
             _clientesAsignadosArolPorUsuariosApiClient = clientesAsignadosArolPorUsuariosApiClient;
             _customersApi = customersApi;
             _userByRoleApiClient = userByRoleApiClient;
@@ -111,11 +109,13 @@ namespace Farmacheck.Controllers
         }
 
         [HttpGet]
-        public async Task<JsonResult> ListarZonas()
+        public async Task<JsonResult> ListarZonas(List<int>? brandIds, List<int>? subbrandIds)
         {
-            var apiData = await _zoneApi.GetZonesAsync();
-            var dtos = _mapper.Map<List<ZonaDto>>(apiData);
-            var zonas = _mapper.Map<List<ZonaViewModel>>(dtos);
+            var apiData = await _businessStructureApiClient.GetBusinessStructuresByFiltersAsync(brandIds, subbrandIds, null);
+            var zonas = apiData
+                .GroupBy(z => z.ZonaId)
+                .Select(g => new ZonaViewModel { Id = g.Key, Nombre = g.First().Zona ?? string.Empty })
+                .ToList();
 
             return Json(new { success = true, data = zonas });
         }

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -249,7 +249,6 @@
 
             cargarRolesModal();
             cargarUnidadesNegocio();
-            cargarZonas();
             $('#unidadDeNegocioSelect').change(function () {
                 cargarMarcas($(this).val());
             });
@@ -286,8 +285,14 @@
                 const seleccionadas = $('#contenedorMarcas .marca-check:checked').map(function () {
                     return parseInt(this.value);
                 }).get();
+                const subSeleccionadas = $('#contenedorSubMarcas .submarca-check:checked').map(function () {
+                    return parseInt(this.value);
+                }).get();
+                const zonasSeleccionadas = $('#contenedorZonas .zona-check:checked').map(function () {
+                    return parseInt(this.value);
+                }).get();
 
-                cargarSubMarcas(seleccionadas);
+                cargarSubMarcas(seleccionadas, subSeleccionadas, zonasSeleccionadas);
                 cargarClientes();
             });
 
@@ -297,7 +302,13 @@
                 const seleccionadas = checked ? $('#contenedorMarcas .marca-check').map(function () {
                     return parseInt(this.value);
                 }).get() : [];
-                cargarSubMarcas(seleccionadas);
+                const subSeleccionadas = $('#contenedorSubMarcas .submarca-check:checked').map(function () {
+                    return parseInt(this.value);
+                }).get();
+                const zonasSeleccionadas = $('#contenedorZonas .zona-check:checked').map(function () {
+                    return parseInt(this.value);
+                }).get();
+                cargarSubMarcas(seleccionadas, subSeleccionadas, zonasSeleccionadas);
                 cargarClientes();
             });
 
@@ -305,12 +316,32 @@
                 const total = $('#contenedorSubMarcas .submarca-check').length;
                 const checked = $('#contenedorSubMarcas .submarca-check:checked').length;
                 $('#checkAllSubMarcas').prop('checked', total > 0 && total === checked);
+                const marcas = $('#contenedorMarcas .marca-check:checked').map(function () {
+                    return parseInt(this.value);
+                }).get();
+                const subbrands = $('#contenedorSubMarcas .submarca-check:checked').map(function () {
+                    return parseInt(this.value);
+                }).get();
+                const zonasSeleccionadas = $('#contenedorZonas .zona-check:checked').map(function () {
+                    return parseInt(this.value);
+                }).get();
+                cargarZonas(marcas, subbrands, zonasSeleccionadas);
                 cargarClientes();
             });
 
             $('#checkAllSubMarcas').change(function () {
                 const checked = this.checked;
                 $('#contenedorSubMarcas .submarca-check').prop('checked', checked);
+                const marcas = $('#contenedorMarcas .marca-check:checked').map(function () {
+                    return parseInt(this.value);
+                }).get();
+                const subbrands = $('#contenedorSubMarcas .submarca-check:checked').map(function () {
+                    return parseInt(this.value);
+                }).get();
+                const zonasSeleccionadas = $('#contenedorZonas .zona-check:checked').map(function () {
+                    return parseInt(this.value);
+                }).get();
+                cargarZonas(marcas, subbrands, zonasSeleccionadas);
                 cargarClientes();
             });
 
@@ -391,7 +422,6 @@
                         if (r.success) {
                             if (parseInt(id) === 0) {
                                 $('#entidadId').val(r.id);
-                                cargarZonas();
                                 usuarioGuardado = true;
                                 $('#collapseRoles').collapse('show');
                             }
@@ -536,7 +566,7 @@
             });
         }
 
-        function cargarMarcas(unidadId, marcasSeleccionadas = [], submarcasSeleccionadas = []) {
+        function cargarMarcas(unidadId, marcasSeleccionadas = [], submarcasSeleccionadas = [], zonasSeleccionadas = []) {
             const contenedor = $('#contenedorMarcas');
             const contenedorSub = $('#contenedorSubMarcas');
             contenedor.empty();
@@ -561,13 +591,13 @@
                     const checkedCount = $('#contenedorMarcas .marca-check:checked').length;
                     $('#checkAllMarcas').prop('checked', total > 0 && total === checkedCount);
                     if (marcasSeleccionadas.length > 0) {
-                        cargarSubMarcas(marcasSeleccionadas, submarcasSeleccionadas);
+                        cargarSubMarcas(marcasSeleccionadas, submarcasSeleccionadas, zonasSeleccionadas);
                     }
                 }
             });
         }
 
-        function cargarSubMarcas(marcaIds, submarcasSeleccionadas = []) {
+        function cargarSubMarcas(marcaIds, submarcasSeleccionadas = [], zonasSeleccionadas = []) {
             const contenedor = $('#contenedorSubMarcas');
             contenedor.empty();
             $('#checkAllSubMarcas').prop('checked', false);
@@ -594,6 +624,7 @@
                         const checkedCount = $('#contenedorSubMarcas .submarca-check:checked').length;
                         $('#checkAllSubMarcas').prop('checked', total > 0 && total === checkedCount);
                         if (submarcasSeleccionadas.length > 0) {
+                            cargarZonas(marcaIds, submarcasSeleccionadas, zonasSeleccionadas);
                             cargarClientes();
                         }
                     }
@@ -601,26 +632,35 @@
             });
         }
 
-        function cargarZonas(zonasSeleccionadas = []) {
+        function cargarZonas(brands = [], subbrands = [], zonasSeleccionadas = []) {
             const contenedor = $('#contenedorZonas');
             contenedor.empty();
             $('#checkAllZonas').prop('checked', false);
-            $.get('@Url.Action("ListarZonas", "Usuario")', function (r) {
-                if (r.success) {
-                    r.data.forEach(z => {
-                        const checked = zonasSeleccionadas.includes(z.id) ? 'checked' : '';
-                        contenedor.append(`
-                            <div class="form-check">
-                                <input class="form-check-input zona-check" type="checkbox" value="${z.id}" id="zona_${z.id}" ${checked}>
-                                <label class="form-check-label" for="zona_${z.id}">${z.nombre}</label>
-                            </div>
-                        `);
-                    });
-                    const total = $('#contenedorZonas .zona-check').length;
-                    const checkedCount = $('#contenedorZonas .zona-check:checked').length;
-                    $('#checkAllZonas').prop('checked', total > 0 && total === checkedCount);
-                    if (zonasSeleccionadas.length > 0) {
-                        cargarClientes();
+            if (!subbrands || subbrands.length === 0) {
+                return;
+            }
+            $.ajax({
+                url: '@Url.Action("ListarZonas", "Usuario")',
+                method: 'GET',
+                traditional: true,
+                data: { brandIds: brands, subbrandIds: subbrands },
+                success: function (r) {
+                    if (r.success) {
+                        r.data.forEach(z => {
+                            const checked = zonasSeleccionadas.includes(z.id) ? 'checked' : '';
+                            contenedor.append(`
+                                <div class="form-check">
+                                    <input class="form-check-input zona-check" type="checkbox" value="${z.id}" id="zona_${z.id}" ${checked}>
+                                    <label class="form-check-label" for="zona_${z.id}">${z.nombre}</label>
+                                </div>
+                            `);
+                        });
+                        const total = $('#contenedorZonas .zona-check').length;
+                        const checkedCount = $('#contenedorZonas .zona-check:checked').length;
+                        $('#checkAllZonas').prop('checked', total > 0 && total === checkedCount);
+                        if (zonasSeleccionadas.length > 0) {
+                            cargarClientes();
+                        }
                     }
                 }
             });
@@ -912,8 +952,7 @@
                     clientesSeleccionados = r.data.clienteIds || [];
                     $('#rolSelectModal').val(r.data.rolId);
                     $('#unidadDeNegocioSelect').val(r.data.unidadDeNegocioId);
-                    cargarZonas(r.data.zonaIds || []);
-                    cargarMarcas(r.data.unidadDeNegocioId, r.data.marcaIds || [], r.data.submarcaIds || []);
+                    cargarMarcas(r.data.unidadDeNegocioId, r.data.marcaIds || [], r.data.submarcaIds || [], r.data.zonaIds || []);
                 } else {
                     showAlert(r.error || 'Error al obtener datos', 'error');
                 }


### PR DESCRIPTION
## Summary
- Fetch zones filtered by selected brands and subbrands via BusinessStructure API
- Preserve selected subbrands and update zones only after subbrand checkbox changes
- Wire controller and client script to new filtering behavior

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4201797f4833183f55ff17936ebb9