### PR TITLE
Fix processing modal visibility in Usuario Index view

### DIFF
--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -689,17 +689,17 @@
                 return;
             }
 
-            // ⬇️ Mostrar modal al iniciar
-            
-            
-            
-            $('#processingModal').modal('show');
-
             $.ajax({
                 url: '@Url.Action("ListarZonas", "Usuario")',
                 method: 'GET',
                 traditional: true,
                 data: { brandIds: brands, subbrandIds: subbrands },
+                beforeSend: function () {
+                    $('#processingModal').modal('show');
+                },
+                complete: function () {
+                    $('#processingModal').modal('hide');
+                },
                 success: function (r) {
                     if (r.success) {
                         r.data.forEach(z => {
@@ -715,11 +715,10 @@
                         $('#countZonas').text(`(${total})`);
                         const checkedCount = $('#contenedorZonas .zona-check:checked').length;
                         $('#checkAllZonas').prop('checked', total > 0 && total === checkedCount);
-                                                
+
                         if (zonasSeleccionadas.length > 0) {
                             cargarClientes();
                         }
-                        $('#processingModal').modal('hide');
                     }
                 }
             });


### PR DESCRIPTION
## Summary
- Ensure processing modal shows before the AJAX call and hides after completion in `cargarZonas`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a67b12a1b883319f8b32fc7448a62b