### PR TITLE
feat(usuario): add report download

### DIFF
--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -351,6 +351,14 @@ namespace Farmacheck.Controllers
             return Json(new { success = true, data = counts });
         }
 
+        [HttpGet]
+        public async Task<IActionResult> DescargarReporte()
+        {
+            var base64 = await _apiClient.GetReport();
+            var bytes = Convert.FromBase64String(base64);
+            return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "ReporteUsuarios.xlsx");
+        }
+
         
     }
 }

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -6,10 +6,14 @@
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h4 class="text-dark">Usuarios</h4>
-        <button id="btnNuevo" class="btn" style="background-color:#00ab8e; color:white;">
-            <i class="bi bi-plus-circle"></i> Nuevo usuario
-        </button>
-        
+        <div>
+            <button id="btnDescargar" class="btn btn-secondary me-2">
+                <i class="bi bi-download"></i> Descargar
+            </button>
+            <button id="btnNuevo" class="btn" style="background-color:#00ab8e; color:white;">
+                <i class="bi bi-plus-circle"></i> Nuevo usuario
+            </button>
+        </div>
     </div>
     <table class="table table-bordered custom-table" id="tablaDatos">
         <thead>
@@ -398,6 +402,9 @@
                 } else {
                     cargarTablaRoles(rolesUsuarioIds);
                 }
+            });
+            $('#btnDescargar').click(function () {
+                descargarReporte();
             });
             $('#btnNuevo').click(function () {
                 limpiar();
@@ -877,6 +884,20 @@
                     });
                 }
             });
+        }
+
+        function descargarReporte() {
+            fetch('@Url.Action("DescargarReporte", "Usuario")')
+                .then(r => r.blob())
+                .then(blob => {
+                    const url = window.URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = 'ReporteUsuarios.xlsx';
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                });
         }
 
         function editar(id) {


### PR DESCRIPTION
## Summary
- allow downloading the users report from index using `IUserApiClient.GetReport`
- add Descargar button and JavaScript handler on Users index page

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f003370c8331b5c39177ada253f2