### PR TITLE
Enable role and business unit selects only during editing

### DIFF
--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -288,6 +288,8 @@
                     return;
                 }
                 $('#idRolPorUsuario').val('');
+                $('#rolSelectModal').prop('disabled', false);
+                $('#unidadDeNegocioSelect').prop('disabled', false);
             });
 
             $('#collapseRoles').on('show.bs.collapse', function (e) {
@@ -998,8 +1000,8 @@
 
         function limpiarModalGestionRol() {
             $('#idRolPorUsuario').val('');
-            $('#rolSelectModal').val('');
-            $('#unidadDeNegocioSelect').val('');
+            $('#rolSelectModal').val('').prop('disabled', false);
+            $('#unidadDeNegocioSelect').val('').prop('disabled', false);
             $('#checkAllMarcas').prop('checked', false);
             $('#checkAllSubMarcas').prop('checked', false);
             $('#checkAllZonas').prop('checked', false);
@@ -1040,8 +1042,8 @@
             $.get('@Url.Action("ObtenerClientesPorRolPorUsuario", "Usuario")', { id }, function (r) {
                 if (r.success) {
                     clientesSeleccionados = r.data.clienteIds || [];
-                    $('#rolSelectModal').val(r.data.rolId);
-                    $('#unidadDeNegocioSelect').val(r.data.unidadDeNegocioId);
+                    $('#rolSelectModal').val(r.data.rolId).prop('disabled', true);
+                    $('#unidadDeNegocioSelect').val(r.data.unidadDeNegocioId).prop('disabled', true);
                     cargarMarcas(r.data.unidadDeNegocioId, r.data.marcaIds || [], r.data.submarcaIds || [], r.data.zonaIds || []);
                 } else {
                     showAlert(r.error || 'Error al obtener datos', 'error');


### PR DESCRIPTION
## Summary
- Keep role and business unit selectors enabled for new role assignments
- Disable role and business unit selectors when editing an existing user role
- Reset selectors to enabled state when clearing the role management modal

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ace5a674188331ab1a6b91ed57e463