### PR TITLE
Add assignments modal to form configuration page

### DIFF
--- a/Farmacheck/Controllers/FormulariosController.cs
+++ b/Farmacheck/Controllers/FormulariosController.cs
@@ -371,5 +371,14 @@ namespace Farmacheck.Controllers
             _formularios.Remove(formulario);
             return Json(new { success = true });
         }
+
+        [HttpPost]
+        public JsonResult GuardarAsignaciones([FromBody] AsignacionFormularioInputModel model)
+        {
+            if (model == null || model.FormularioId == 0)
+                return Json(new { success = false, error = "Datos inválidos" });
+
+            return Json(new { success = true, message = "Asignaciones guardadas (simulación)" });
+        }
     }
 }

--- a/Farmacheck/Models/Inputs/AsignacionFormularioInputModel.cs
+++ b/Farmacheck/Models/Inputs/AsignacionFormularioInputModel.cs
@@ -1,0 +1,10 @@
+namespace Farmacheck.Models.Inputs
+{
+    public class AsignacionFormularioInputModel
+    {
+        public int FormularioId { get; set; }
+        public int? Rol1 { get; set; }
+        public int? Rol2 { get; set; }
+        public int? Rol3 { get; set; }
+    }
+}

--- a/Farmacheck/Views/Formularios/ConfigurarFormulario.cshtml
+++ b/Farmacheck/Views/Formularios/ConfigurarFormulario.cshtml
@@ -11,6 +11,7 @@
            href="@Url.Action("Index", "Formularios", new { id = ViewBag.FormularioId })">
             <i class="bi bi-arrow-left"></i> Regresar
         </a>
+        <button type="button" class="btn btn-secondary" id="btnAsignaciones">Asignaciones</button>
     </div>
     <h4 class=" text-white p-3 rounded" style="background-color:#0c4c98">@(isEditing ? "Actualizar Formulario" : "Guardar Formulario")</h4>
 
@@ -252,12 +253,49 @@
         </div>
     </div>
 
+    <!-- Modal de asignaciones -->
+    <div class="modal fade" id="modalAsignaciones" tabindex="-1" aria-labelledby="modalAsignacionesLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header bg-primary_form text-white">
+                    <h5 class="modal-title" id="modalAsignacionesLabel">Asignaciones</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" id="idFormularioAsignacion" />
+                    <div class="mb-3">
+                        <label>Rol 1</label>
+                        <select id="rolSelect1" class="form-select">
+                            <option value="">-- Seleccione --</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label>Rol 2</label>
+                        <select id="rolSelect2" class="form-select">
+                            <option value="">-- Seleccione --</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label>Rol 3</label>
+                        <select id="rolSelect3" class="form-select">
+                            <option value="">-- Seleccione --</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" id="btnGuardarAsignaciones">Guardar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
 </div>
 @section Scripts {
     <script>
         $(document).ready(function () {
             const params = new URLSearchParams(window.location.search);
             const id = params.get('id');
+            $('#idFormularioAsignacion').val(id);
             if (id) {
                 $.get('@Url.Action("ObtenerFormulario", "Formularios")', { id }, function (r) {
                     if (r.success) {
@@ -349,6 +387,52 @@
 
         $('#btnAceptarGuardado').click(function () {
             window.location.href = '@Url.Action("Index", "Formularios")';
+        });
+
+        function cargarRolesAsignaciones() {
+            const selects = ['#rolSelect1', '#rolSelect2', '#rolSelect3'];
+            selects.forEach(s => $(s).empty().append('<option value="">-- Seleccione --</option>'));
+            $.get('@Url.Action("ListarGestion", "Rol")', function (r) {
+                if (r.success) {
+                    selects.forEach(s => {
+                        r.data.forEach(rol => $(s).append(`<option value="${rol.id}">${rol.nombre}</option>`));
+                    });
+                } else {
+                    showAlert(r.error || 'Error al cargar roles', 'error');
+                }
+            });
+        }
+
+        $('#btnAsignaciones').click(function () {
+            cargarRolesAsignaciones();
+            $('#modalAsignaciones').modal('show');
+        });
+
+        $('#btnGuardarAsignaciones').click(function () {
+            const data = {
+                FormularioId: parseInt($('#idFormularioAsignacion').val() || 0),
+                Rol1: $('#rolSelect1').val(),
+                Rol2: $('#rolSelect2').val(),
+                Rol3: $('#rolSelect3').val()
+            };
+
+            $.ajax({
+                url: '@Url.Action("GuardarAsignaciones", "Formularios")',
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify(data),
+                success: function (r) {
+                    if (r.success) {
+                        showAlert(r.message || 'Asignaciones guardadas correctamente', 'success');
+                        $('#modalAsignaciones').modal('hide');
+                    } else {
+                        showAlert(r.error || 'Error al guardar asignaciones', 'error');
+                    }
+                },
+                error: function () {
+                    showAlert('Error en la petición', 'error');
+                }
+            });
         });
     </script>
 }


### PR DESCRIPTION
## Summary
- add assignments button and modal with three role selects
- mock controller endpoint and input model for assignment saving
- wire modal scripts to load roles and simulate save via SweetAlert

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8363bf4c83319f32d9a339b7431b