### PR TITLE
Enable multi-select role assignments in checklist form

### DIFF
--- a/Farmacheck/Models/Inputs/AsignacionFormularioInputModel.cs
+++ b/Farmacheck/Models/Inputs/AsignacionFormularioInputModel.cs
@@ -1,10 +1,12 @@
+using System.Collections.Generic;
+
 namespace Farmacheck.Models.Inputs
 {
     public class AsignacionFormularioInputModel
     {
         public int FormularioId { get; set; }
-        public int? Rol1 { get; set; }
+        public List<int> Rol1 { get; set; } = new();
         public int? Rol2 { get; set; }
-        public int? Rol3 { get; set; }
+        public List<int> Rol3 { get; set; } = new();
     }
 }

--- a/Farmacheck/Views/Formularios/ConfigurarFormulario.cshtml
+++ b/Farmacheck/Views/Formularios/ConfigurarFormulario.cshtml
@@ -227,8 +227,7 @@
                     <input type="hidden" id="idFormularioAsignacion" />
                     <div class="mb-3">
                         <label>Rol 1</label>
-                        <select id="rolSelect1" class="form-select">
-                            <option value="">-- Seleccione --</option>
+                        <select id="rolSelect1" class="form-select" multiple>
                         </select>
                     </div>
                     <div class="mb-3">
@@ -239,8 +238,7 @@
                     </div>
                     <div class="mb-3">
                         <label>Rol 3</label>
-                        <select id="rolSelect3" class="form-select">
-                            <option value="">-- Seleccione --</option>
+                        <select id="rolSelect3" class="form-select" multiple>
                         </select>
                     </div>
                 </div>
@@ -360,12 +358,17 @@
         }
         
         function cargarRolesAsignaciones() {
-            const selects = ['#rolSelect1', '#rolSelect2', '#rolSelect3'];
-            selects.forEach(s => $(s).empty().append('<option value="">-- Seleccione --</option>'));
+            const multiSelects = ['#rolSelect1', '#rolSelect3'];
+            const singleSelect = '#rolSelect2';
+
+            multiSelects.forEach(s => $(s).empty());
+            $(singleSelect).empty().append('<option value="">-- Seleccione --</option>');
+
             $.get('@Url.Action("ListarGestion", "Rol")', function (r) {
                 if (r.success) {
-                    selects.forEach(s => {
-                        r.data.forEach(rol => $(s).append(`<option value="${rol.id}">${rol.nombre}</option>`));
+                    r.data.forEach(rol => {
+                        multiSelects.forEach(s => $(s).append(`<option value="${rol.id}">${rol.nombre}</option>`));
+                        $(singleSelect).append(`<option value="${rol.id}">${rol.nombre}</option>`);
                     });
                 } else {
                     showAlert(r.error || 'Error al cargar roles', 'error');
@@ -381,9 +384,9 @@
         $('#btnGuardarAsignaciones').click(function () {
             const data = {
                 FormularioId: parseInt($('#idFormularioAsignacion').val() || 0),
-                Rol1: $('#rolSelect1').val(),
+                Rol1: ($('#rolSelect1').val() || []).map(Number),
                 Rol2: $('#rolSelect2').val(),
-                Rol3: $('#rolSelect3').val()
+                Rol3: ($('#rolSelect3').val() || []).map(Number)
             };
 
             $.ajax({


### PR DESCRIPTION
## Summary
- Allow selecting multiple roles for "Rol 1" and "Rol 3" in the Asignaciones modal
- Load roles for multi-select controls and send arrays to the server
- Update AsignacionFormularioInputModel to accept role lists

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aff8b57268833180f1441d1cc05c73