### PR TITLE
Enable multi-select role assignments with Choices.js

### DIFF
--- a/Farmacheck/Models/Inputs/AsignacionFormularioInputModel.cs
+++ b/Farmacheck/Models/Inputs/AsignacionFormularioInputModel.cs
@@ -1,10 +1,12 @@
+using System.Collections.Generic;
+
 namespace Farmacheck.Models.Inputs
 {
     public class AsignacionFormularioInputModel
     {
         public int FormularioId { get; set; }
-        public int? Rol1 { get; set; }
+        public List<int> Rol1 { get; set; } = new();
         public int? Rol2 { get; set; }
-        public int? Rol3 { get; set; }
+        public List<int> Rol3 { get; set; } = new();
     }
 }

--- a/Farmacheck/Views/Formularios/ConfigurarFormulario.cshtml
+++ b/Farmacheck/Views/Formularios/ConfigurarFormulario.cshtml
@@ -227,9 +227,7 @@
                     <input type="hidden" id="idFormularioAsignacion" />
                     <div class="mb-3">
                         <label>Rol 1</label>
-                        <select id="rolSelect1" class="form-select">
-                            <option value="">-- Seleccione --</option>
-                        </select>
+                        <select id="rolSelect1" class="form-select choices-dropdown" multiple></select>
                     </div>
                     <div class="mb-3">
                         <label>Rol 2</label>
@@ -239,9 +237,7 @@
                     </div>
                     <div class="mb-3">
                         <label>Rol 3</label>
-                        <select id="rolSelect3" class="form-select">
-                            <option value="">-- Seleccione --</option>
-                        </select>
+                        <select id="rolSelect3" class="form-select choices-dropdown" multiple></select>
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -255,10 +251,16 @@
 
 @section Scripts {
     <script>
+        let rol1Choices;
+        let rol3Choices;
+
         $(document).ready(function () {
             cargarCategorias();
 
-             $('#imagenArchivo').change(function () {
+            rol1Choices = new Choices('#rolSelect1', { removeItemButton: true });
+            rol3Choices = new Choices('#rolSelect3', { removeItemButton: true });
+
+            $('#imagenArchivo').change(function () {
                 const file = this.files[0];
                 $('#imagenNombre').val(file ? file.name : '');
             });
@@ -360,13 +362,15 @@
         }
         
         function cargarRolesAsignaciones() {
-            const selects = ['#rolSelect1', '#rolSelect2', '#rolSelect3'];
-            selects.forEach(s => $(s).empty().append('<option value="">-- Seleccione --</option>'));
+            rol1Choices.clearStore();
+            rol3Choices.clearStore();
+            $('#rolSelect2').empty().append('<option value="">-- Seleccione --</option>');
             $.get('@Url.Action("ListarGestion", "Rol")', function (r) {
                 if (r.success) {
-                    selects.forEach(s => {
-                        r.data.forEach(rol => $(s).append(`<option value="${rol.id}">${rol.nombre}</option>`));
-                    });
+                    const opciones = r.data.map(rol => ({ value: rol.id, label: rol.nombre }));
+                    rol1Choices.setChoices(opciones, 'value', 'label', true);
+                    rol3Choices.setChoices(opciones, 'value', 'label', true);
+                    r.data.forEach(rol => $('#rolSelect2').append(`<option value="${rol.id}">${rol.nombre}</option>`));
                 } else {
                     showAlert(r.error || 'Error al cargar roles', 'error');
                 }
@@ -381,9 +385,9 @@
         $('#btnGuardarAsignaciones').click(function () {
             const data = {
                 FormularioId: parseInt($('#idFormularioAsignacion').val() || 0),
-                Rol1: $('#rolSelect1').val(),
+                Rol1: rol1Choices.getValue(true).map(Number),
                 Rol2: $('#rolSelect2').val(),
-                Rol3: $('#rolSelect3').val()
+                Rol3: rol3Choices.getValue(true).map(Number)
             };
 
             $.ajax({

--- a/Farmacheck/Views/Shared/_Layout.cshtml
+++ b/Farmacheck/Views/Shared/_Layout.cshtml
@@ -18,6 +18,7 @@
     <!-- Estilos externos (solo si no usas local) -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
 </head>
 <body>
     <!-- Sidebar -->
@@ -83,6 +84,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
     <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 


### PR DESCRIPTION
## Summary
- Add Choices.js assets for enhanced multi-select support
- Allow roles 1 and 3 to select multiple assignments with Choices.js
- Update assignment input model to handle role arrays

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b09fe61c648331a1c11a91d82ef46d