### PR TITLE
Mostrar descripción de frecuencia en periodicidad de cuestionario

### DIFF
--- a/Farmacheck/Models/PeriodicidadCuestionarioViewModel.cs
+++ b/Farmacheck/Models/PeriodicidadCuestionarioViewModel.cs
@@ -5,5 +5,6 @@ namespace Farmacheck.Models
         public int CuestionarioId { get; set; }
         public int Frecuencia { get; set; }
         public int Meta { get; set; }
+        public string FrecuenciaDescripcion { get; set; }
     }
 }

--- a/Farmacheck/Views/PeriodicidadCuestionario/Index.cshtml
+++ b/Farmacheck/Views/PeriodicidadCuestionario/Index.cshtml
@@ -29,7 +29,7 @@
         {
             <tr>
                 <td>@p.CuestionarioId</td>
-                <td>@p.Frecuencia</td>
+                <td>@p.FrecuenciaDescripcion</td>
                 <td>@p.Meta</td>
                 <td class="text-center">
                     <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(@p.CuestionarioId)"><i class="bi bi-pencil"></i></button>


### PR DESCRIPTION
## Summary
- Map frequency IDs to descriptive text for questionnaire periodicities
- Render descriptive frequency labels in index and list views

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c52e63a88331b0949d52526313a6