### PR TITLE
Filtrar cuestionarios ya registrados en periodicidad

### DIFF
--- a/Farmacheck/Controllers/PeriodicidadCuestionarioController.cs
+++ b/Farmacheck/Controllers/PeriodicidadCuestionarioController.cs
@@ -43,8 +43,19 @@ namespace Farmacheck.Controllers
                     ? desc
                     : item.Frecuencia.ToString();
             }
-            ViewBag.Formularios = await _checklistApiClient.GetAllChecklistsAsync();
             return View(items);
+        }
+
+        [HttpGet]
+        public async Task<JsonResult> FormulariosDisponibles()
+        {
+            var periodicidades = await _apiClient.GetPeriodicitiesAsync();
+            var usados = periodicidades.Select(p => p.CuestionarioId).ToHashSet();
+            var formularios = await _checklistApiClient.GetAllChecklistsAsync();
+            var disponibles = formularios
+                .Where(f => !usados.Contains(f.Id))
+                .Select(f => new { f.Id, f.Nombre });
+            return Json(new { success = true, data = disponibles });
         }
 
         [HttpGet]

--- a/Farmacheck/Views/PeriodicidadCuestionario/Index.cshtml
+++ b/Farmacheck/Views/PeriodicidadCuestionario/Index.cshtml
@@ -50,16 +50,8 @@
             <div class="modal-body">
                 <div class="mb-2">
                     <label>Formulario</label>
-                    @{
-                        var formularios = ViewBag.Formularios as IEnumerable<Farmacheck.Application.Models.Checklists.ChecklistResponse>
-                            ?? System.Linq.Enumerable.Empty<Farmacheck.Application.Models.Checklists.ChecklistResponse>();
-                    }
                     <select class="form-select" id="cuestionarioSelect" required>
                         <option value="" selected disabled>Seleccione</option>
-                        @foreach (var f in formularios)
-                        {
-                            <option value="@f.Id">@f.Nombre</option>
-                        }
                     </select>
                 </div>
                 <div class="mb-2">
@@ -101,8 +93,10 @@
         tabla.on('length.dt', function (e, settings, len) {
             localStorage.setItem('periodicidadesPageLength', len);
         });
+        cargarFormularios();
         $('#btnNuevo').click(function(){
             limpiar();
+            cargarFormularios();
             $('#modalTitulo').text('Nuevo periodo');
             $('#modalEntidad').modal('show');
         });
@@ -167,6 +161,19 @@
                 });
                 nuevaTabla.on('length.dt', function (e, settings, len) {
                     localStorage.setItem('periodicidadesPageLength', len);
+                });
+                cargarFormularios();
+            }
+        });
+    }
+    function cargarFormularios(){
+        $.get('@Url.Action("FormulariosDisponibles","PeriodicidadCuestionario")', function(r){
+            if(r.success){
+                const select = $('#cuestionarioSelect');
+                select.empty();
+                select.append('<option value="" selected disabled>Seleccione</option>');
+                r.data.forEach(f => {
+                    select.append(`<option value="${f.id}">${f.nombre}</option>`);
                 });
             }
         });


### PR DESCRIPTION
## Summary
- Oculta en el formulario los cuestionarios que ya tienen periodicidad registrada
- Carga dinámicamente el listado disponible al abrir el modal o actualizar la tabla

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c9e681788331b6519ff2e99574b0