### PR TITLE
Agregar controlador para gestión de asignaciones de cuestionarios

### DIFF
--- a/Farmacheck/Controllers/AsignacionCuestionarioController.cs
+++ b/Farmacheck/Controllers/AsignacionCuestionarioController.cs
@@ -1,0 +1,49 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.QuizAssignmentManager;
+using Farmacheck.Models;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace Farmacheck.Controllers
+{
+    public class AsignacionCuestionarioController : Controller
+    {
+        private readonly IQuizAssignmentManagerApiClient _apiClient;
+        private readonly IMapper _mapper;
+
+        public AsignacionCuestionarioController(IQuizAssignmentManagerApiClient apiClient, IMapper mapper)
+        {
+            _apiClient = apiClient;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public async Task<JsonResult> Obtener(int cuestionarioId)
+        {
+            var response = await _apiClient.GetQuizAssignmentAsync(cuestionarioId);
+            if (response == null)
+                return Json(new { success = false, error = "No encontrado" });
+
+            var dto = _mapper.Map<QuizAssignmentManagerDto>(response);
+            var model = _mapper.Map<AsignacionCuestionarioViewModel>(dto);
+            return Json(new { success = true, data = model });
+        }
+
+        [HttpPost]
+        public async Task<JsonResult> Guardar([FromBody] AsignacionCuestionarioViewModel model)
+        {
+            var request = _mapper.Map<QuizAssignmentManagerRequest>(model);
+            var result = await _apiClient.CreateAsync(request);
+            return Json(new { success = result });
+        }
+
+        [HttpPost]
+        public async Task<JsonResult> Eliminar([FromBody] AsignacionCuestionarioViewModel model)
+        {
+            var result = await _apiClient.DeleteAsync(model.CuestionarioId, model.AsignacionPorSupervisor, model.AsignacionDeAuditados, model.AsignacionPorAuditor);
+            return Json(new { success = result });
+        }
+    }
+}

--- a/Farmacheck/Helpers/WebMappingProfile.cs
+++ b/Farmacheck/Helpers/WebMappingProfile.cs
@@ -18,6 +18,7 @@ using Farmacheck.Application.Models.ResponseFormatByQuestion;
 using Farmacheck.Application.Models.SubBrands;
 using Farmacheck.Application.Models.Users;
 using Farmacheck.Application.Models.Zones;
+using Farmacheck.Application.Models.QuizAssignmentManager;
 using Farmacheck.Models;
 using Farmacheck.Models.Inputs;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -191,6 +192,8 @@ namespace Farmacheck.Helpers
             CreateMap<UsuarioRolViewModel, UserByRoleRequest>();
             CreateMap<UsuarioRolViewModel, UpdateUserByRoleRequest>();
             CreateMap<RolPorUsuarioClientesAsignadosDto, RolPorUsuarioClientesAsignadosViewModel>().ReverseMap();
+            CreateMap<QuizAssignmentManagerDto, AsignacionCuestionarioViewModel>().ReverseMap();
+            CreateMap<AsignacionCuestionarioViewModel, QuizAssignmentManagerRequest>();
         }
     }
 }

--- a/Farmacheck/Models/AsignacionCuestionarioViewModel.cs
+++ b/Farmacheck/Models/AsignacionCuestionarioViewModel.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Farmacheck.Models
+{
+    public class AsignacionCuestionarioViewModel
+    {
+        public int CuestionarioId { get; set; }
+        public List<int> AsignacionPorSupervisor { get; set; } = new();
+        public List<int> AsignacionDeAuditados { get; set; } = new();
+        public List<int> AsignacionPorAuditor { get; set; } = new();
+        public int? AsignadoPor { get; set; }
+    }
+}

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -28,6 +28,7 @@ namespace Farmacheck
                 typeof(PeriodicityByQuestionnaireProfile),
                 typeof(RoleProfile),
                 typeof(PermissionProfile),
+                typeof(QuizAssignmentManagerProfile),
                 typeof(HierarchyByRoleProfile),
                 typeof(UserProfile));
 


### PR DESCRIPTION
## Summary
- Implementar **AsignacionCuestionarioController** que utiliza `IQuizAssignmentManagerApiClient`
- Agregar modelo `AsignacionCuestionarioViewModel` y mappings de AutoMapper
- Registrar `QuizAssignmentManagerProfile` en el arranque de la aplicación

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(falla: comando no encontrado)*
- `apt-get update` *(falla: repositorios 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a6d298d88331ad36aad908b86d10