### PR TITLE
Implement assignment save endpoint and integrate modal

### DIFF
--- a/Farmacheck/Controllers/AsignacionCuestionarioController.cs
+++ b/Farmacheck/Controllers/AsignacionCuestionarioController.cs
@@ -34,6 +34,9 @@ namespace Farmacheck.Controllers
         [HttpPost]
         public async Task<JsonResult> Guardar([FromBody] AsignacionCuestionarioViewModel model)
         {
+            if (model == null || model.CuestionarioId <= 0)
+                return Json(new { success = false, error = "Datos inválidos" });
+
             var request = _mapper.Map<QuizAssignmentManagerRequest>(model);
             var result = await _apiClient.CreateAsync(request);
             return Json(new { success = result });

--- a/Farmacheck/Views/Formularios/ConfigurarFormulario.cshtml
+++ b/Farmacheck/Views/Formularios/ConfigurarFormulario.cshtml
@@ -421,14 +421,14 @@
 
         $('#btnGuardarAsignaciones').click(function () {
             const data = {
-                FormularioId: parseInt($('#idFormularioAsignacion').val() || 0),
-                Rol1: rol1Choices.getValue(true).map(Number),
-                Rol2: $('#rolSelect2').val(),
-                Rol3: rol3Choices.getValue(true).map(Number)
+                CuestionarioId: parseInt($('#idFormularioAsignacion').val() || 0),
+                AsignacionPorAuditor: rol1Choices.getValue(true).map(Number),
+                AsignacionDeAuditados: $('#rolSelect2').val() ? [parseInt($('#rolSelect2').val())] : [],
+                AsignacionPorSupervisor: rol3Choices.getValue(true).map(Number)
             };
 
             $.ajax({
-                url: '@Url.Action("GuardarAsignaciones", "Formularios")',
+                url: '@Url.Action("Guardar", "AsignacionCuestionario")',
                 method: 'POST',
                 contentType: 'application/json',
                 data: JSON.stringify(data),


### PR DESCRIPTION
## Summary
- validate incoming data and persist assignments via API client
- hook up assignment modal to AsignacionCuestionario controller and send expected payload

## Testing
- ⚠️ `dotnet build Farmacheck/Farmacheck.sln` *(command not found: dotnet)*
- ⚠️ `apt-get update` *(403 Forbidden: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b7e30db083319399dd0f3d1cf375