### PR TITLE
Add roles by business unit endpoint support

### DIFF
--- a/Farmacheck.Application/Interfaces/IRoleApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IRoleApiClient.cs
@@ -6,6 +6,7 @@ namespace Farmacheck.Application.Interfaces
     public interface IRoleApiClient
     {
         Task<IEnumerable<RoleResponse>> GetAllRolesAsync();
+        Task<IEnumerable<RoleResponse>> GetRolesByBusinessUnitAsync(byte businessUnitId);
         Task<List<RoleResponse>> GetRolesAsync();
         Task<PaginatedResponse<RoleResponse>> GetRolesByPageAsync(int page, int items);
         Task<RoleResponse?> GetRoleAsync(byte id);

--- a/Farmacheck.Infrastructure/Services/RolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/RolesApiClient.cs
@@ -20,6 +20,12 @@ namespace Farmacheck.Infrastructure.Services
                    ?? Enumerable.Empty<RoleResponse>();
         }
 
+        public async Task<IEnumerable<RoleResponse>> GetRolesByBusinessUnitAsync(byte businessUnitId)
+        {
+            return await _http.GetFromJsonAsync<IEnumerable<RoleResponse>>($"api/v1/Roles/businessunit/{businessUnitId}")
+                   ?? Enumerable.Empty<RoleResponse>();
+        }
+
         public async Task<List<RoleResponse>> GetRolesAsync()
         {
             return await _http.GetFromJsonAsync<List<RoleResponse>>("api/v1/Roles")

--- a/Farmacheck/Controllers/RolController.cs
+++ b/Farmacheck/Controllers/RolController.cs
@@ -73,6 +73,23 @@ namespace Farmacheck.Controllers
         }
 
         [HttpGet]
+        public async Task<JsonResult> ListarPorUnidadNegocio(int unidadId)
+        {
+            var apiData = await _apiClient.GetRolesByBusinessUnitAsync((byte)unidadId);
+            var dtos = _mapper.Map<List<RoleDto>>(apiData);
+            var roles = _mapper.Map<List<RolViewModel>>(dtos);
+
+            var unidadesApi = await _businessUnitApi.GetBusinessUnitsAsync();
+            foreach (var r in roles)
+            {
+                var u = unidadesApi.FirstOrDefault(b => b.Id == r.UnidadDeNegocioId);
+                r.UnidadDeNegocioNombre = u?.Nombre;
+            }
+
+            return Json(new { success = true, data = roles });
+        }
+
+        [HttpGet]
         public async Task<JsonResult> ListarGestion()
         {
             var apiData = await _apiClient.GetRolesAsync();


### PR DESCRIPTION
## Summary
- add IRoleApiClient method to fetch roles by business unit
- implement RolesApiClient call for new endpoint
- expose ListarPorUnidadNegocio action in RolController

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b50da2292c8331b13ce2093eba0d0f