### PR TITLE
Limpia componentes al crear rol por usuario

### DIFF
--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -291,9 +291,7 @@
                     showAlert('Primero guarda el usuario', 'warning');
                     return;
                 }
-                $('#idRolPorUsuario').val('');
-                $('#rolSelectModal').prop('disabled', false);
-                $('#unidadDeNegocioSelect').prop('disabled', false);
+                limpiarModalGestionRol();
             });
 
             $('#collapseRoles').on('show.bs.collapse', function (e) {
@@ -1016,6 +1014,8 @@
             $('#contenedorMarcas').empty();
             $('#contenedorSubMarcas').empty();
             $('#contenedorClientes').empty();
+            $('#countMarcas').text('(0)');
+            $('#countSubMarcas').text('(0)');
             clientesSeleccionados = [];
             cargarZonas();
         }


### PR DESCRIPTION
## Resumen
- Limpieza completa de la gestión de roles al abrir "Nuevo rol por Usuario".
- Restaurar contadores de Marcas y Submarcas a 0 al reiniciar el modal.

## Pruebas
- `dotnet build Farmacheck/Farmacheck.sln` *(falla: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b60f070dd083319cd2e0da309d9e91