### PR TITLE
Add authentication API client and models

### DIFF
--- a/Farmacheck.Application/DTOs/TokenDto.cs
+++ b/Farmacheck.Application/DTOs/TokenDto.cs
@@ -1,0 +1,8 @@
+namespace Farmacheck.Application.DTOs;
+
+public class TokenDto
+{
+    public string Token { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+    public DateTime Expiration { get; set; }
+}

--- a/Farmacheck.Application/DTOs/UserInfoDto.cs
+++ b/Farmacheck.Application/DTOs/UserInfoDto.cs
@@ -1,0 +1,7 @@
+namespace Farmacheck.Application.DTOs;
+
+public class UserInfoDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+}

--- a/Farmacheck.Application/Interfaces/IAuthApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IAuthApiClient.cs
@@ -1,0 +1,12 @@
+using Farmacheck.Application.Models.Security;
+
+namespace Farmacheck.Application.Interfaces;
+
+public interface IAuthApiClient
+{
+    Task<bool> ValidateAsync(string token);
+    Task<UserInfoResponse?> GetUserInfoAsync(string token);
+    Task<TokenResponse?> LoginAsync(CredentialsRequest request);
+    Task<TokenResponse?> RefreshAsync(RegenerateRequest request);
+    Task<bool> LogoutAsync(string token);
+}

--- a/Farmacheck.Application/Mappings/AuthProfile.cs
+++ b/Farmacheck.Application/Mappings/AuthProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Application.Models.Security;
+
+namespace Farmacheck.Application.Mappings;
+
+public class AuthProfile : Profile
+{
+    public AuthProfile()
+    {
+        CreateMap<TokenResponse, TokenDto>().ReverseMap();
+        CreateMap<UserInfoResponse, UserInfoDto>().ReverseMap();
+    }
+}

--- a/Farmacheck.Application/Models/Security/CredentialsRequest.cs
+++ b/Farmacheck.Application/Models/Security/CredentialsRequest.cs
@@ -1,0 +1,7 @@
+namespace Farmacheck.Application.Models.Security;
+
+public class CredentialsRequest
+{
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/Farmacheck.Application/Models/Security/RegenerateRequest.cs
+++ b/Farmacheck.Application/Models/Security/RegenerateRequest.cs
@@ -1,0 +1,7 @@
+namespace Farmacheck.Application.Models.Security;
+
+public class RegenerateRequest
+{
+    public string Token { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/Farmacheck.Application/Models/Security/TokenResponse.cs
+++ b/Farmacheck.Application/Models/Security/TokenResponse.cs
@@ -1,0 +1,8 @@
+namespace Farmacheck.Application.Models.Security;
+
+public class TokenResponse
+{
+    public string Token { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+    public DateTime Expiration { get; set; }
+}

--- a/Farmacheck.Application/Models/Security/UserInfoResponse.cs
+++ b/Farmacheck.Application/Models/Security/UserInfoResponse.cs
@@ -1,0 +1,7 @@
+namespace Farmacheck.Application.Models.Security;
+
+public class UserInfoResponse
+{
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+}

--- a/Farmacheck.Infrastructure/DependencyInjection.cs
+++ b/Farmacheck.Infrastructure/DependencyInjection.cs
@@ -124,6 +124,11 @@ public static class DependencyInjection
             client.BaseAddress = new Uri(configuration["QuizAssignmentManagerApi:BaseUrl"]!);
         });
 
+        services.AddHttpClient<IAuthApiClient, AuthApiClient>(client =>
+        {
+            client.BaseAddress = new Uri(configuration["AuthApi:BaseUrl"]!);
+        });
+
         return services;
     }
 }

--- a/Farmacheck.Infrastructure/Services/AuthApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/AuthApiClient.cs
@@ -1,0 +1,65 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.Security;
+
+namespace Farmacheck.Infrastructure.Services;
+
+public class AuthApiClient : IAuthApiClient
+{
+    private readonly HttpClient _http;
+
+    public AuthApiClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<bool> ValidateAsync(string token)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "api/v1/security/Auth");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _http.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<ApiResponse<bool>>();
+        return result?.Data ?? false;
+    }
+
+    public async Task<UserInfoResponse?> GetUserInfoAsync(string token)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "api/v1/security/Auth/user");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _http.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<ApiResponse<UserInfoResponse>>();
+        return result?.Data;
+    }
+
+    public async Task<TokenResponse?> LoginAsync(CredentialsRequest requestModel)
+    {
+        var response = await _http.PostAsJsonAsync("api/v1/security/Auth", requestModel);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TokenResponse>();
+    }
+
+    public async Task<TokenResponse?> RefreshAsync(RegenerateRequest requestModel)
+    {
+        var response = await _http.PutAsJsonAsync("api/v1/security/Auth", requestModel);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TokenResponse>();
+    }
+
+    public async Task<bool> LogoutAsync(string token)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Delete, "api/v1/security/Auth");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _http.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<bool>();
+        return result;
+    }
+
+    private class ApiResponse<T>
+    {
+        public T? Data { get; set; }
+    }
+}

--- a/Farmacheck/Controllers/AuthController.cs
+++ b/Farmacheck/Controllers/AuthController.cs
@@ -1,0 +1,94 @@
+using AutoMapper;
+using Farmacheck.Application.Interfaces;
+using Farmacheck.Application.Models.Security;
+using Farmacheck.Application.DTOs;
+using Farmacheck.Models;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace Farmacheck.Controllers;
+
+public class AuthController : Controller
+{
+    private readonly IAuthApiClient _apiClient;
+    private readonly IMapper _mapper;
+
+    public AuthController(IAuthApiClient apiClient, IMapper mapper)
+    {
+        _apiClient = apiClient;
+        _mapper = mapper;
+    }
+
+    [HttpGet]
+    public async Task<JsonResult> Validate()
+    {
+        Request.Headers.TryGetValue("Authorization", out var authorizationHeader);
+        if (!string.IsNullOrEmpty(authorizationHeader))
+        {
+            var token = authorizationHeader.First().Replace("Bearer ", string.Empty);
+            var result = await _apiClient.ValidateAsync(token);
+            return Json(new { success = true, data = result });
+        }
+        return Json(new { success = false, error = "Token not provided" });
+    }
+
+    [HttpGet("user")]
+    public async Task<JsonResult> GetUser()
+    {
+        Request.Headers.TryGetValue("Authorization", out var authorizationHeader);
+        if (!string.IsNullOrEmpty(authorizationHeader))
+        {
+            var token = authorizationHeader.First().Replace("Bearer ", string.Empty);
+            var info = await _apiClient.GetUserInfoAsync(token);
+            var dto = _mapper.Map<UserInfoDto>(info);
+            var model = _mapper.Map<UserInfoViewModel>(dto);
+            return Json(new { success = true, data = model });
+        }
+        return Json(new { success = false, error = "Token not provided" });
+    }
+
+    [HttpPost]
+    public async Task<JsonResult> Login([FromBody] CredentialsRequest model)
+    {
+        try
+        {
+            var response = await _apiClient.LoginAsync(model);
+            var dto = _mapper.Map<TokenDto>(response);
+            var vm = _mapper.Map<TokenViewModel>(dto);
+            return Json(new { success = true, data = vm });
+        }
+        catch (Exception ex)
+        {
+            return Json(new { success = false, error = ex.Message });
+        }
+    }
+
+    [HttpPut]
+    public async Task<JsonResult> Refresh([FromBody] RegenerateRequest model)
+    {
+        try
+        {
+            var response = await _apiClient.RefreshAsync(model);
+            var dto = _mapper.Map<TokenDto>(response);
+            var vm = _mapper.Map<TokenViewModel>(dto);
+            return Json(new { success = true, data = vm });
+        }
+        catch (Exception ex)
+        {
+            return Json(new { success = false, error = ex.Message });
+        }
+    }
+
+    [HttpDelete]
+    public async Task<JsonResult> Logout()
+    {
+        Request.Headers.TryGetValue("Authorization", out var authorizationHeader);
+        if (!string.IsNullOrEmpty(authorizationHeader))
+        {
+            var token = authorizationHeader.First().Replace("Bearer ", string.Empty);
+            var result = await _apiClient.LogoutAsync(token);
+            return Json(new { success = true, data = result });
+        }
+        return Json(new { success = false, error = "Token not provided" });
+    }
+}

--- a/Farmacheck/Helpers/WebMappingProfile.cs
+++ b/Farmacheck/Helpers/WebMappingProfile.cs
@@ -205,6 +205,9 @@ namespace Farmacheck.Helpers
             CreateMap<RolPorUsuarioClientesAsignadosDto, RolPorUsuarioClientesAsignadosViewModel>().ReverseMap();
             CreateMap<QuizAssignmentManagerDto, AsignacionCuestionarioViewModel>().ReverseMap();
             CreateMap<AsignacionCuestionarioViewModel, QuizAssignmentManagerRequest>();
+
+            CreateMap<TokenDto, TokenViewModel>().ReverseMap();
+            CreateMap<UserInfoDto, UserInfoViewModel>().ReverseMap();
         }
     }
 }

--- a/Farmacheck/Models/TokenViewModel.cs
+++ b/Farmacheck/Models/TokenViewModel.cs
@@ -1,0 +1,8 @@
+namespace Farmacheck.Models;
+
+public class TokenViewModel
+{
+    public string Token { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+    public DateTime Expiration { get; set; }
+}

--- a/Farmacheck/Models/UserInfoViewModel.cs
+++ b/Farmacheck/Models/UserInfoViewModel.cs
@@ -1,0 +1,7 @@
+namespace Farmacheck.Models;
+
+public class UserInfoViewModel
+{
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+}

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -30,7 +30,8 @@ namespace Farmacheck
                 typeof(PermissionProfile),
                 typeof(QuizAssignmentManagerProfile),
                 typeof(HierarchyByRoleProfile),
-                typeof(UserProfile));
+                typeof(UserProfile),
+                typeof(AuthProfile));
 
             builder.Services.AddInfrastructure(builder.Configuration);
 

--- a/Farmacheck/appsettings.json
+++ b/Farmacheck/appsettings.json
@@ -75,9 +75,13 @@
     "BaseUrl": "https://localhost:7205"
   },
 
-  "QuizAssignmentManagerApi": {
-    "BaseUrl": "https://localhost:7205"
+    "QuizAssignmentManagerApi": {
+      "BaseUrl": "https://localhost:7205"
+    },
+
+    "AuthApi": {
+      "BaseUrl": "https://localhost:7205"
+    }
+
+
   }
-
-
-}


### PR DESCRIPTION
## Summary
- add security models and auth API client
- wire up AutoMapper profiles and dependency injection
- include web controller and view models for authentication

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b90c12c5fc833187910bda30444988