### PR TITLE
Implement token cookie after login

### DIFF
--- a/Farmacheck/Controllers/AuthController.cs
+++ b/Farmacheck/Controllers/AuthController.cs
@@ -4,6 +4,7 @@ using Farmacheck.Application.Models.Security;
 using Farmacheck.Application.DTOs;
 using Farmacheck.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using System.Linq;
 
 namespace Farmacheck.Controllers;
@@ -55,6 +56,17 @@ public class AuthController : Controller
             var response = await _apiClient.LoginAsync(model);
             var dto = _mapper.Map<TokenDto>(response);
             var vm = _mapper.Map<TokenViewModel>(dto);
+
+            var cookieOptions = new CookieOptions
+            {
+                HttpOnly = true,
+                Secure = true,
+                SameSite = SameSiteMode.Strict,
+                Expires = vm.Expiration
+            };
+
+            Response.Cookies.Append("AuthToken", vm.Token, cookieOptions);
+
             return Json(new { success = true, data = vm });
         }
         catch (Exception ex)

--- a/Farmacheck/Views/Security/Login.cshtml
+++ b/Farmacheck/Views/Security/Login.cshtml
@@ -30,26 +30,21 @@
                 @* <img src="images/farmacheck_logo_trazado.svg" alt="Farmacheck" style="height: 60px;"> *@
                 <h4 style="color: #004080; margin-top: 1rem;">Iniciar sesión</h4>
             </div>
-            <form method="post" action="/login">
+            <form id="loginForm">
                 <div style="margin-bottom: 1rem;">
                     <label for="email" style="font-weight: bold;">Correo electrónico</label>
                     <input type="email" id="email" name="email" placeholder="usuario@dominio.com"
-                           style="width: 100%; padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px;">
+                           style="width: 100%; padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px;" required>
                 </div>
                 <div style="margin-bottom: 1.5rem;">
                     <label for="password" style="font-weight: bold;">Contraseña</label>
                     <input type="password" id="password" name="password" placeholder="••••••••"
-                           style="width: 100%; padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px;">
+                           style="width: 100%; padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px;" required>
                 </div>
                 <div>
-                    
-                    <button type="button"
-                            onclick="location.href='@Url.Action("Index", "Formularios")'"
-                            style="width: 100%; background-color: #007bff; color: white; border: none; padding: 0.6rem; border-radius: 4px;">
+                    <button type="submit" style="width: 100%; background-color: #007bff; color: white; border: none; padding: 0.6rem; border-radius: 4px;">
                         Entrar
                     </button>
-
-
                 </div>
             </form>
             <div style="text-align: center; margin-top: 1rem;">
@@ -57,6 +52,28 @@
             </div>
         </div>
     </div>
+    <script>
+        document.getElementById('loginForm').addEventListener('submit', async function (e) {
+            e.preventDefault();
+            const email = document.getElementById('email').value;
+            const password = document.getElementById('password').value;
 
+            const response = await fetch('/Auth/Login', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                credentials: 'include',
+                body: JSON.stringify({ email: email, password: password })
+            });
+
+            const result = await response.json();
+            if (response.ok && result.success) {
+                window.location.href = '@Url.Action("Index", "Formularios")';
+            } else {
+                alert(result.error || 'Error al iniciar sesión');
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- store JWT in secure AuthToken cookie during login
- post login form via fetch and redirect after successful authentication

## Testing
- ⚠️ `dotnet build Farmacheck/Farmacheck.sln` (dotnet: command not found)
- ⚠️ `apt-get update` (403  Forbidden [IP: 172.30.0.179 8080])

------
https://chatgpt.com/codex/tasks/task_e_68b913b1834083319cf9ca01e87ae8db