### PR TITLE
Add user menu with logout and username display

### DIFF
--- a/Farmacheck/Views/Security/Login.cshtml
+++ b/Farmacheck/Views/Security/Login.cshtml
@@ -69,6 +69,10 @@
 
             const result = await response.json();
             if (response.ok && result.success) {
+                localStorage.setItem('username', email);
+                if (result.data && result.data.token) {
+                    localStorage.setItem('token', result.data.token);
+                }
                 window.location.href = '@Url.Action("Index", "Formularios")';
             } else {
                 alert(result.error || 'Error al iniciar sesión');

--- a/Farmacheck/Views/Shared/_Layout.cshtml
+++ b/Farmacheck/Views/Shared/_Layout.cshtml
@@ -69,11 +69,25 @@
         <nav class="navbar navbar-light bg-white border-bottom shadow-sm p-2">
             <div class="container-fluid d-flex align-items-center justify-content-between">
                 <button class="menu-toggle d-md-none me-2" aria-label="Abrir menú lateral" onclick="toggleSidebar()">☰</button>
-                <img src="~/images/Logo_HeaderBlank.png" style="height: 55px;" class="ms-auto" />
+                <img src="~/images/Logo_HeaderBlank.png" style="height: 55px;" />
+                <button class="btn p-0 ms-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#userOffcanvas" aria-label="Usuario">
+                    <i class="bi bi-person-circle" style="font-size: 1.8rem;"></i>
+                </button>
             </div>
             <img src="~/images/linea_header.png" style="width: 100%; height: auto; display: block; margin-top: 5px;" />
         </nav>
     </header>
+
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="userOffcanvas" aria-labelledby="userOffcanvasLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="userOffcanvasLabel">Usuario</h5>
+            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Cerrar"></button>
+        </div>
+        <div class="offcanvas-body">
+            <button id="logoutBtn" class="btn btn-outline-danger w-100 mb-3">Cerrar sesión</button>
+            <div id="userNameDisplay" class="fw-bold"></div>
+        </div>
+    </div>
 
     <!-- Contenido principal -->
     <div class="main-content" style="margin-left: 240px; padding: 20px;">
@@ -101,6 +115,33 @@
             const sidebar = document.getElementById('sidebar');
             sidebar.classList.toggle('show');
         }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const userNameDisplay = document.getElementById('userNameDisplay');
+            const username = localStorage.getItem('username');
+            if (userNameDisplay && username) {
+                userNameDisplay.textContent = username;
+            }
+
+            const logoutBtn = document.getElementById('logoutBtn');
+            if (logoutBtn) {
+                logoutBtn.addEventListener('click', async () => {
+                    const token = localStorage.getItem('token');
+                    try {
+                        await fetch('/Auth/Logout', {
+                            method: 'DELETE',
+                            headers: token ? { 'Authorization': `Bearer ${token}` } : {},
+                            credentials: 'include'
+                        });
+                    } catch (err) {
+                        // ignore errors
+                    }
+                    localStorage.removeItem('token');
+                    localStorage.removeItem('username');
+                    window.location.href = '/Security/Login';
+                });
+            }
+        });
     </script>
 
     @await RenderSectionAsync("Scripts", required: false)


### PR DESCRIPTION
## Summary
- Add user icon and offcanvas menu to layout with logout option and username display
- Store user name and token in local storage on login for later use

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b91bd8bb5483319392256344be7517