### PR TITLE
Handle null login token with SweetAlert error

### DIFF
--- a/Farmacheck/Controllers/AuthController.cs
+++ b/Farmacheck/Controllers/AuthController.cs
@@ -57,6 +57,11 @@ public class AuthController : Controller
             var dto = _mapper.Map<TokenDto>(response);
             var vm = _mapper.Map<TokenViewModel>(dto);
 
+            if (string.IsNullOrEmpty(vm?.Token))
+            {
+                return Json(new { success = false, error = "Credenciales incorrectas, favor de verificar." });
+            }
+
             var cookieOptions = new CookieOptions
             {
                 HttpOnly = true,

--- a/Farmacheck/Views/Security/Login.cshtml
+++ b/Farmacheck/Views/Security/Login.cshtml
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </head>
 <body style="background-color: #f8f9fa;">
     <header>
@@ -78,7 +79,11 @@
                 window.location.href = '@Url.Action("Index", "Formularios")';
             } else {
                 const message = (response.ok && result.success) ? 'Autenticación incorrecta verificar mail o contraseña' : (result.error || 'Error al iniciar sesión');
-                alert(message);
+                Swal.fire({
+                    icon: 'error',
+                    title: 'Error',
+                    text: message
+                });
             }
         });
 


### PR DESCRIPTION
## Summary
- return error when login token is missing instead of setting cookie
- use SweetAlert on login page to show authentication failures

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors while attempting to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ea24ef908331b04175173b2cb446