### PR TITLE
style: use brand color for logout button

### DIFF
--- a/Farmacheck/Views/Shared/_Layout.cshtml
+++ b/Farmacheck/Views/Shared/_Layout.cshtml
@@ -77,7 +77,7 @@
                     <div id="userDropdownMenu" class="dropdown-menu dropdown-menu-end shadow rounded-3 p-3" style="width: 360px;">
                         @* <h6 class="mb-3 text-center">Usuario</h6> *@
                         <div id="userNameDisplay" class="fw-bold text-center text-dark"></div>
-                        <button id="logoutBtn" class="btn btn-outline-danger w-100 mb-2">Cerrar sesión</button>
+                        <button id="logoutBtn" class="btn btn-outline-brand w-100 mb-2">Cerrar sesión</button>
                     </div>
                 </div>
             </div>

--- a/Farmacheck/wwwroot/css/site.css
+++ b/Farmacheck/wwwroot/css/site.css
@@ -165,6 +165,18 @@ a[onclick^="eliminar"],
     color: white !important;
 }
 
+.btn-outline-brand {
+    color: #004a99 !important;
+    border-color: #004a99 !important;
+}
+
+.btn-outline-brand:hover,
+.btn-outline-brand:focus {
+    color: #fff !important;
+    background-color: #004a99 !important;
+    border-color: #004a99 !important;
+}
+
 .backdrop-oscuro .modal-backdrop {
     background-color: #000;
 }


### PR DESCRIPTION
## Summary
- add custom outline button style using blue #004a99
- apply brand-colored outline style to logout button

## Testing
- `dotnet test Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ed52d8708331be57faf2ea5eac9c