### PR TITLE
Add geolocation active toggle to user editor

### DIFF
--- a/Farmacheck.Application/DTOs/UserDto.cs
+++ b/Farmacheck.Application/DTOs/UserDto.cs
@@ -9,6 +9,7 @@ namespace Farmacheck.Application.DTOs
         public string Email { get; set; } = null!;
         public long? NumeroDeTelefono { get; set; }
         public bool Estatus { get; set; }
+        public bool GeolocalizacionActiva { get; set; }
         public DateTime CreadoEl { get; set; }
         public DateTime ActualizadoEl { get; set; }
     }

--- a/Farmacheck.Application/Models/Users/UpdateUserRequest.cs
+++ b/Farmacheck.Application/Models/Users/UpdateUserRequest.cs
@@ -7,5 +7,6 @@ namespace Farmacheck.Application.Models.Users
         [Required]
         public int Id { get; set; }
         public bool Estatus { get; set; }
+        public bool GeolocalizacionActiva { get; set; }
     }
 }

--- a/Farmacheck.Application/Models/Users/UserRequest.cs
+++ b/Farmacheck.Application/Models/Users/UserRequest.cs
@@ -8,5 +8,6 @@ namespace Farmacheck.Application.Models.Users
         public string Email { get; set; }
         public long? NumeroDeTelefono { get; set; }
         public bool Estatus { get; set; }
+        public bool GeolocalizacionActiva { get; set; }
     }
 }

--- a/Farmacheck.Application/Models/Users/UserResponse.cs
+++ b/Farmacheck.Application/Models/Users/UserResponse.cs
@@ -9,6 +9,7 @@ namespace Farmacheck.Application.Models.Users
         public string Email { get; set; } = null!;
         public long? NumeroDeTelefono { get; set; }
         public bool Estatus { get; set; }
+        public bool GeolocalizacionActiva { get; set; }
         public DateTime CreadoEl { get; set; }
         public DateTime ActualizadoEl { get; set; }
     }

--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -156,7 +156,7 @@ namespace Farmacheck.Controllers
                             {
                                 RolPorUsuarioId = model.Id,
                                 Clientes = nuevos,
-                                GeolocalizacionActiva = true
+                                GeolocalizacionActiva = model.GeolocalizacionActiva
                             };
                             await _customersRolesUsersApiClient.CreateAsync(addRequest);
                         }
@@ -193,7 +193,7 @@ namespace Farmacheck.Controllers
                 {
                     RolPorUsuarioId = userRoleId,
                     Clientes = model.ClienteIds ?? new List<long>(),
-                    GeolocalizacionActiva = true
+                    GeolocalizacionActiva = model.GeolocalizacionActiva
                 };
 
                 customerRolUserResult = await _customersRolesUsersApiClient.CreateAsync(customerRolUserRequest);

--- a/Farmacheck/Models/UsuarioRolViewModel.cs
+++ b/Farmacheck/Models/UsuarioRolViewModel.cs
@@ -12,5 +12,6 @@ namespace Farmacheck.Models
         public string? UnidadDeNegocioNombre { get; set; }
         public int TotalClientesAsignados { get; set; }
         public List<long> ClienteIds { get; set; } = new();
+        public bool GeolocalizacionActiva { get; set; }
     }
 }

--- a/Farmacheck/Models/UsuarioViewModel.cs
+++ b/Farmacheck/Models/UsuarioViewModel.cs
@@ -9,6 +9,7 @@ namespace Farmacheck.Models
         public string Email { get; set; } = null!;
         public long? NumeroDeTelefono { get; set; }
         public bool Estatus { get; set; }
+        public bool GeolocalizacionActiva { get; set; }
         public DateTime CreadoEl { get; set; }
         public DateTime ActualizadoEl { get; set; }
     }

--- a/Farmacheck/Views/Usuario/Index.cshtml
+++ b/Farmacheck/Views/Usuario/Index.cshtml
@@ -86,6 +86,12 @@
                             <label class="form-check-label" for="estatusCheck">Habilitado</label>
                         </div>
                     </div>
+                    <div class="col-md-3 d-flex align-items-center">
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input" type="checkbox" id="geolocalizacionCheck">
+                            <label class="form-check-label" for="geolocalizacionCheck">Geolocalización activa</label>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- Botones de acción -->
@@ -442,7 +448,8 @@
                     ApellidoMaterno: $('#apellidoMaterno').val(),
                     Email: $('#email').val(),
                     NumeroDeTelefono: $('#telefono').val(),
-                    Estatus: $('#estatusCheck').prop('checked')
+                    Estatus: $('#estatusCheck').prop('checked'),
+                    GeolocalizacionActiva: $('#geolocalizacionCheck').prop('checked')
                 };
 
                 $.ajax({
@@ -481,7 +488,8 @@
                 if (idRolPorUsuario) {
                     const datosUpdate = {
                         Id: parseInt(idRolPorUsuario),
-                        ClienteIds: clienteIds
+                        ClienteIds: clienteIds,
+                        GeolocalizacionActiva: $('#geolocalizacionCheck').prop('checked')
                     };
 
                     const ejecutar = function () {
@@ -535,7 +543,8 @@
                     RolId: parseInt(rolId),
                     UnidadDeNegocioId: parseInt(unidadId),
                     AsignadoPor: 1,
-                    ClienteIds: clienteIds
+                    ClienteIds: clienteIds,
+                    GeolocalizacionActiva: $('#geolocalizacionCheck').prop('checked')
                 };
 
                 $.ajax({
@@ -938,6 +947,7 @@
                     $('#email').val(u.email);
                     $('#telefono').val(u.numeroDeTelefono);
                     $('#estatusCheck').prop('checked', u.estatus);
+                    $('#geolocalizacionCheck').prop('checked', u.geolocalizacionActiva);
 
                     cargarSelectorRoles();
                     usuarioGuardado = true;
@@ -973,6 +983,7 @@
             $('#email').val('');
             $('#telefono').val('');
             $('#estatusCheck').prop('checked', true);
+            $('#geolocalizacionCheck').prop('checked', true);
 
             // Limpiar select de rol
             const selectRol = $('#selectRol');


### PR DESCRIPTION
## Summary
- Add geolocalización activa switch to user edit modal and related scripts
- Plumb geolocalización activa through user and role models and controller

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1aca78448331b4a6d137f3733b7b