### PR TITLE
Sync user models with new geolocation flag

### DIFF
--- a/Farmacheck.Application/DTOs/UserDto.cs
+++ b/Farmacheck.Application/DTOs/UserDto.cs
@@ -9,8 +9,9 @@ namespace Farmacheck.Application.DTOs
         public string Email { get; set; } = null!;
         public long? NumeroDeTelefono { get; set; }
         public bool Estatus { get; set; }
-        public bool GeolocalizacionActiva { get; set; }
         public DateTime CreadoEl { get; set; }
         public DateTime ActualizadoEl { get; set; }
+        public bool ActualizaPass { get; set; }
+        public bool GeolocalizacionActiva { get; set; }
     }
 }

--- a/Farmacheck.Application/Models/Users/UpdateUserRequest.cs
+++ b/Farmacheck.Application/Models/Users/UpdateUserRequest.cs
@@ -2,11 +2,17 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Farmacheck.Application.Models.Users
 {
-    public class UpdateUserRequest : UserRequest
+    public class UpdateUserRequest
     {
         [Required]
         public int Id { get; set; }
+        public string Nombre { get; set; }
+        public string ApellidoPaterno { get; set; }
+        public string? ApellidoMaterno { get; set; }
+        public string Email { get; set; }
+        public long? NumeroDeTelefono { get; set; }
         public bool Estatus { get; set; }
+        public bool ActualizaPass { get; set; }
         public bool GeolocalizacionActiva { get; set; }
     }
 }

--- a/Farmacheck.Application/Models/Users/UserRequest.cs
+++ b/Farmacheck.Application/Models/Users/UserRequest.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Farmacheck.Application.Models.Users
 {
     public class UserRequest
@@ -7,7 +9,8 @@ namespace Farmacheck.Application.Models.Users
         public string? ApellidoMaterno { get; set; }
         public string Email { get; set; }
         public long? NumeroDeTelefono { get; set; }
-        public bool Estatus { get; set; }
+        public List<int>? Roles { get; set; }
+        public int AsignadoPor { get; set; }
         public bool GeolocalizacionActiva { get; set; }
     }
 }

--- a/Farmacheck.Application/Models/Users/UserResponse.cs
+++ b/Farmacheck.Application/Models/Users/UserResponse.cs
@@ -9,8 +9,9 @@ namespace Farmacheck.Application.Models.Users
         public string Email { get; set; } = null!;
         public long? NumeroDeTelefono { get; set; }
         public bool Estatus { get; set; }
-        public bool GeolocalizacionActiva { get; set; }
         public DateTime CreadoEl { get; set; }
         public DateTime ActualizadoEl { get; set; }
+        public bool ActualizaPass { get; set; }
+        public bool GeolocalizacionActiva { get; set; }
     }
 }

--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -234,7 +234,6 @@ namespace Farmacheck.Controllers
                     return Json(new { success = false, error = "El nombre es obligatorio." });
 
                 var request = _mapper.Map<UserRequest>(model);
-                request.Estatus = model.Estatus;
 
                 if (model.Id == 0)
                 {
@@ -244,7 +243,6 @@ namespace Farmacheck.Controllers
                 else
                 {
                     var updateRequest = _mapper.Map<UpdateUserRequest>(model);
-                    updateRequest.Estatus = model.Estatus;
                     var updated = await _apiClient.UpdateAsync(updateRequest);
                     if (updated)
                         return Json(new { success = true, id = model.Id });

--- a/Farmacheck/Models/UsuarioViewModel.cs
+++ b/Farmacheck/Models/UsuarioViewModel.cs
@@ -9,8 +9,9 @@ namespace Farmacheck.Models
         public string Email { get; set; } = null!;
         public long? NumeroDeTelefono { get; set; }
         public bool Estatus { get; set; }
-        public bool GeolocalizacionActiva { get; set; }
         public DateTime CreadoEl { get; set; }
         public DateTime ActualizadoEl { get; set; }
+        public bool ActualizaPass { get; set; }
+        public bool GeolocalizacionActiva { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- extend user request models with roles, assignment and geolocation flag
- add password-update and geolocation fields to user DTOs and responses
- rely on AutoMapper in UsuarioController for updated user mapping

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be5129da688331bea2e25a2800a9c2