### PR TITLE
Enforce login via auth token middleware

### DIFF
--- a/Farmacheck/Middleware/AuthTokenMiddleware.cs
+++ b/Farmacheck/Middleware/AuthTokenMiddleware.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Builder;
+
+namespace Farmacheck.Middleware
+{
+    public class AuthTokenMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private const string AuthCookie = "AuthToken";
+        private const string LoginPath = "/Security/Login";
+
+        public AuthTokenMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            var path = context.Request.Path;
+
+            if (path.StartsWithSegments(LoginPath, System.StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWithSegments("/Auth", System.StringComparison.OrdinalIgnoreCase) ||
+                Path.HasExtension(path))
+            {
+                await _next(context);
+                return;
+            }
+
+            if (!context.Request.Cookies.ContainsKey(AuthCookie))
+            {
+                context.Response.Redirect(LoginPath);
+                return;
+            }
+
+            await _next(context);
+        }
+    }
+
+    public static class AuthTokenMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseAuthToken(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<AuthTokenMiddleware>();
+        }
+    }
+}

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -2,6 +2,7 @@ using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Mappings;
 using Farmacheck.Helpers;
 using Farmacheck.Infrastructure;
+using Farmacheck.Middleware;
 namespace Farmacheck
 {
     public class Program
@@ -47,6 +48,8 @@ namespace Farmacheck
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();
+
+            app.UseAuthToken();
 
             app.UseRouting();
 


### PR DESCRIPTION
## Summary
- add middleware to check for AuthToken cookie and redirect to login
- wire middleware into request pipeline

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: dotnet command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be6508520883319be45a42451ce736