### PR TITLE
Delete auth cookie on logout

### DIFF
--- a/Farmacheck/Controllers/AuthController.cs
+++ b/Farmacheck/Controllers/AuthController.cs
@@ -100,12 +100,24 @@ public class AuthController : Controller
     public async Task<JsonResult> Logout()
     {
         Request.Headers.TryGetValue("Authorization", out var authorizationHeader);
+
+        var cookieOptions = new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.Strict,
+            Path = "/"
+        };
+
         if (!string.IsNullOrEmpty(authorizationHeader))
         {
             var token = authorizationHeader.First().Replace("Bearer ", string.Empty);
             var result = await _apiClient.LogoutAsync(token);
+            Response.Cookies.Delete("AuthToken", cookieOptions);
             return Json(new { success = true, data = result });
         }
+
+        Response.Cookies.Delete("AuthToken", cookieOptions);
         return Json(new { success = false, error = "Token not provided" });
     }
 }


### PR DESCRIPTION
## Summary
- ensure the auth cookie is removed when logging out so the session terminates properly

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be688f65a0833182e5ade9fb557d77