### PR TITLE
Include bearer token for business unit requests

### DIFF
--- a/Farmacheck.Infrastructure/Farmacheck.Infrastructure.csproj
+++ b/Farmacheck.Infrastructure/Farmacheck.Infrastructure.csproj
@@ -13,6 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Farmacheck.Application\Farmacheck.Application.csproj" />
   </ItemGroup>
 </Project>

--- a/Farmacheck.Infrastructure/Services/BusinessUnitApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/BusinessUnitApiClient.cs
@@ -2,32 +2,53 @@ using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.BusinessUnits;
 using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 
 namespace Farmacheck.Infrastructure.Services
 {
     public class BusinessUnitApiClient : IBusinessUnitApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public BusinessUnitApiClient(HttpClient http)
+        public BusinessUnitApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<IEnumerable<BusinessUnitResponse>> GetAllBusinessUnitsAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<IEnumerable<BusinessUnitResponse>>("api/v1/BusinessUnits/all")
                    ?? Enumerable.Empty<BusinessUnitResponse>();
         }
 
         public async Task<List<BusinessUnitResponse>> GetBusinessUnitsAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<BusinessUnitResponse>>("api/v1/BusinessUnits")
                    ?? new List<BusinessUnitResponse>();
         }
 
         public async Task<PaginatedResponse<BusinessUnitResponse>> GetBusinessUnitsByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/BusinessUnits/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<BusinessUnitResponse>>(url)
                       ?? new PaginatedResponse<BusinessUnitResponse>();
@@ -37,11 +58,13 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<BusinessUnitResponse?> GetBusinessUnitAsync(int id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<BusinessUnitResponse>($"api/v1/BusinessUnits/{id}");
         }
 
         public async Task<int> CreateAsync(BusinessUnitRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/BusinessUnits", request);
             response.EnsureSuccessStatusCode();
             var id = await response.Content.ReadFromJsonAsync<int>();
@@ -50,6 +73,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(BusinessUnitRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/BusinessUnits", request);
             response.EnsureSuccessStatusCode();
             var updated = await response.Content.ReadFromJsonAsync<bool>();
@@ -58,12 +82,14 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/BusinessUnits/{id}");
             response.EnsureSuccessStatusCode();
         }
 
         public async Task<string> GetReport()
         {
+            AddBearerToken();
             var response = await _http.GetAsync("api/v1/BusinessUnits/report");
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync();

--- a/Farmacheck/Program.cs
+++ b/Farmacheck/Program.cs
@@ -13,6 +13,7 @@ namespace Farmacheck
 
             // Add services to the container.
             builder.Services.AddControllersWithViews();
+            builder.Services.AddHttpContextAccessor();
 
             //builder.Services.AddAutoMapper(typeof(BrandProfile).Assembly);
             //builder.Services.AddAutoMapper(typeof(WebMappingProfile), typeof(BrandProfile));


### PR DESCRIPTION
## Summary
- attach AuthToken cookie as Bearer header in BusinessUnit API calls
- register `IHttpContextAccessor` and reference `Microsoft.AspNetCore.App`

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.67 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68c05e1bbd4083319e63307a535fba99