### PR TITLE
Include bearer token in Subbrand, Zone and Customer API clients

### DIFF
--- a/Farmacheck.Infrastructure/Services/CustomersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CustomersApiClient.cs
@@ -6,32 +6,53 @@ using System.Linq;
 using Farmacheck.Application.Models.BusinessUnits;
 using System.Text.Json;
 using Farmacheck.Application.Models.Common;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 
 namespace Farmacheck.Infrastructure.Services
 {
     public class CustomersApiClient : ICustomersApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public CustomersApiClient(HttpClient http)
+        public CustomersApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<IEnumerable<CustomerResponse>> GetAllCustomersAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<IEnumerable<CustomerResponse>>("api/v1/Customers/all")
                    ?? Enumerable.Empty<CustomerResponse>();
         }
 
         public async Task<List<CustomerResponse>> GetCustomersAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<CustomerResponse>>("api/v1/Customers")
                    ?? new List<CustomerResponse>();
         }
 
         public async Task<PaginatedResponse<CustomerResponse>> GetCustomersByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/Customers/pages?page={page}&items={items}";
             var res= await _http.GetFromJsonAsync<PaginatedResponse<CustomerResponse>>(url)
                    ?? new PaginatedResponse<CustomerResponse>();
@@ -41,27 +62,29 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<List<CustomerResponse>> GetCustomersByFiltersAsync( IEnumerable<int>? brand, IEnumerable<int>? subbrand, IEnumerable<int>? zone)
         {
-                var query = new List<string>();
+            AddBearerToken();
+            var query = new List<string>();
 
-                if (brand != null && brand.Any())
-                    query.Add(string.Join("&", brand.Select(b => $"brand={b}")));
+            if (brand != null && brand.Any())
+                query.Add(string.Join("&", brand.Select(b => $"brand={b}")));
 
-                if (subbrand != null && subbrand.Any())
-                    query.Add(string.Join("&", subbrand.Select(s => $"subbrand={s}")));
+            if (subbrand != null && subbrand.Any())
+                query.Add(string.Join("&", subbrand.Select(s => $"subbrand={s}")));
 
-                if (zone != null && zone.Any())
-                    query.Add(string.Join("&", zone.Select(z => $"zone={z}")));
+            if (zone != null && zone.Any())
+                query.Add(string.Join("&", zone.Select(z => $"zone={z}")));
 
-                var url = "api/v1/Customers/filters";
-                if (query.Any())
-                    url += "?" + string.Join("&", query);
+            var url = "api/v1/Customers/filters";
+            if (query.Any())
+                url += "?" + string.Join("&", query);
 
-                return await _http.GetFromJsonAsync<List<CustomerResponse>>(url)
-                       ?? new List<CustomerResponse>();
+            return await _http.GetFromJsonAsync<List<CustomerResponse>>(url)
+                   ?? new List<CustomerResponse>();
         }
 
         public async Task<List<BusinessUnitResponse>> GetBusinessUnitsByRoleAsync(int rolByUser)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<BusinessUnitResponse>>($"api/v1/Customers/rolesPorUsuario/{rolByUser}")
                    ?? new List<BusinessUnitResponse>();
         }
@@ -69,6 +92,7 @@ namespace Farmacheck.Infrastructure.Services
         {
             try
             {
+                AddBearerToken();
                 return await _http.GetFromJsonAsync<CustomerResponse>($"api/v1/Customers/{id}");
             }
             
@@ -84,6 +108,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<int> CreateAsync(CustomerRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/Customers", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<int>();
@@ -91,6 +116,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(UpdateCustomerRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/Customers", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<bool>();
@@ -98,12 +124,14 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/Customers/{id}");
             response.EnsureSuccessStatusCode();
         }
 
         public async Task<string> GetReport()
         {
+            AddBearerToken();
             var response = await _http.GetAsync("api/v1/Customers/report");
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync();

--- a/Farmacheck.Infrastructure/Services/SubbrandApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/SubbrandApiClient.cs
@@ -3,32 +3,53 @@ using Farmacheck.Application.Models.SubBrands;
 using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 
 namespace Farmacheck.Infrastructure.Services
 {
     public class SubbrandApiClient : ISubbrandApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public SubbrandApiClient(HttpClient http)
+        public SubbrandApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<IEnumerable<SubbrandResponse>> GetAllSubbrandsAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<IEnumerable<SubbrandResponse>>("api/v1/Subbrands/all")
                    ?? Enumerable.Empty<SubbrandResponse>();
         }
 
         public async Task<List<SubbrandResponse>> GetSubbrandsAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<SubbrandResponse>>("api/v1/Subbrands")
                    ?? new List<SubbrandResponse>();
         }
 
         public async Task<PaginatedResponse<SubbrandResponse>> GetSubbrandsByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/Subbrands/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<SubbrandResponse>>(url)
                       ?? new PaginatedResponse<SubbrandResponse>();
@@ -37,6 +58,7 @@ namespace Farmacheck.Infrastructure.Services
         }
         public async Task<List<SubbrandResponse>> GetSubbrandsByBrandsAsync(List<int> brands)
         {
+            AddBearerToken();
             var query = string.Join("&", brands.Select(b => $"brands={b}"));
             var url = $"api/v1/Subbrands/brand?{query}";
             return await _http.GetFromJsonAsync<List<SubbrandResponse>>(url)
@@ -44,11 +66,13 @@ namespace Farmacheck.Infrastructure.Services
         }
         public async Task<SubbrandResponse?> GetSubbrandAsync(int id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<SubbrandResponse>($"api/v1/Subbrands/{id}");
         }
 
         public async Task<int> CreateAsync(SubbrandRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/Subbrands", request);
             response.EnsureSuccessStatusCode();
 
@@ -57,6 +81,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(UpdateSubbrandRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/Subbrands", request);
             response.EnsureSuccessStatusCode();
 
@@ -65,12 +90,14 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/Subbrands/{id}");
             response.EnsureSuccessStatusCode();
         }
 
         public async Task<string> GetReport()
         {
+            AddBearerToken();
             var response = await _http.GetAsync("api/v1/Subbrands/report");
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync();

--- a/Farmacheck.Infrastructure/Services/ZonesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/ZonesApiClient.cs
@@ -2,32 +2,53 @@ using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Zones;
 using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 
 namespace Farmacheck.Infrastructure.Services
 {
     public class ZonesApiClient : IZoneApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public ZonesApiClient(HttpClient http)
+        public ZonesApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<IEnumerable<ZoneResponse>> GetAllZonesAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<IEnumerable<ZoneResponse>>("api/v1/Zones/all")
                    ?? Enumerable.Empty<ZoneResponse>();
         }
 
         public async Task<List<ZoneResponse>> GetZonesAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<ZoneResponse>>("api/v1/Zones")
                    ?? new List<ZoneResponse>();
         }
 
         public async Task<PaginatedResponse<ZoneResponse>> GetZonesByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/Zones/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<ZoneResponse>>(url)
                       ?? new PaginatedResponse<ZoneResponse>();
@@ -37,11 +58,13 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<ZoneResponse?> GetZoneAsync(int id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<ZoneResponse>($"api/v1/Zones/{id}");
         }
 
         public async Task<int> CreateAsync(ZoneRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/Zones", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<int>();
@@ -49,6 +72,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(UpdateZoneRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/Zones", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<bool>();
@@ -56,12 +80,14 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/Zones/{id}");
             response.EnsureSuccessStatusCode();
         }
 
         public async Task<string> GetReport()
         {
+            AddBearerToken();
             var response = await _http.GetAsync("api/v1/Zones/report");
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
## Summary
- Add authentication header injection using cookie token for Subbrand API client
- Apply same bearer token handling to Zones API client
- Ensure Customers API client sends bearer token with requests

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f3f33b748331abf56ae7fd55827f