### PR TITLE
Add bearer token support for authorization across API clients

### DIFF
--- a/Farmacheck.Infrastructure/Services/CategoryByQuestionnaireApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CategoryByQuestionnaireApiClient.cs
@@ -1,6 +1,8 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.CategoriesByQuestionnaires;
 using Farmacheck.Application.Models.Common;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -8,14 +10,31 @@ namespace Farmacheck.Infrastructure.Services
     public class CategoryByQuestionnaireApiClient : ICategoryByQuestionnaireApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public CategoryByQuestionnaireApiClient(HttpClient http)
+        public CategoryByQuestionnaireApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<IEnumerable<CategoryByQuestionnaireResponse>> GetAllCategoriesAsync()
         {
+            AddBearerToken();
             var categories = await _http.GetFromJsonAsync<IEnumerable<CategoryByQuestionnaireResponse>>("api/v1/CategoriesByChecklists")
                    ?? Enumerable.Empty<CategoryByQuestionnaireResponse>();
 
@@ -24,12 +43,14 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<List<CategoryByQuestionnaireResponse>> GetCategoriesAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<CategoryByQuestionnaireResponse>>("api/v1/CategoriesByChecklists")
                    ?? new List<CategoryByQuestionnaireResponse>();
         }
 
         public async Task<PaginatedResponse<CategoryByQuestionnaireResponse>> GetCategoriesByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/CategoriesByChecklists/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<CategoryByQuestionnaireResponse>>(url)
                       ?? new PaginatedResponse<CategoryByQuestionnaireResponse>();
@@ -39,16 +60,19 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<CategoryByQuestionnaireResponse?> GetCategoryAsync(byte id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<CategoryByQuestionnaireResponse>($"api/v1/CategoriesByChecklists/{id}");
         }
 
         public async Task<CategoryByQuestionnaireResponse?> GetByNameAsync(string name)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<CategoryByQuestionnaireResponse>($"api/v1/CategoriesByChecklists/name/{name}");
         }
 
         public async Task<byte> CreateAsync(CategoryByQuestionnaireRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/CategoriesByChecklists", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<byte>();
@@ -56,6 +80,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(UpdateCategoryByQuestionnaireRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/CategoriesByChecklists", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<bool>();
@@ -65,6 +90,7 @@ namespace Farmacheck.Infrastructure.Services
         {
             try
             {
+                AddBearerToken();
                 var response = await _http.DeleteAsync($"api/v1/CategoriesByChecklists/{id}");
                 response.EnsureSuccessStatusCode();
             }

--- a/Farmacheck.Infrastructure/Services/HierarchyByRolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/HierarchyByRolesApiClient.cs
@@ -1,6 +1,8 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Common;
 using Farmacheck.Application.Models.HierarchyByRoles;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -8,26 +10,45 @@ namespace Farmacheck.Infrastructure.Services
     public class HierarchyByRolesApiClient : IHierarchyByRoleApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public HierarchyByRolesApiClient(HttpClient http)
+        public HierarchyByRolesApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<IEnumerable<HierarchyByRoleResponse>> GetAllHierarchyByRolesAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<IEnumerable<HierarchyByRoleResponse>>("api/v1/HierarchyByRole/all")
                    ?? Enumerable.Empty<HierarchyByRoleResponse>();
         }
 
         public async Task<List<HierarchyByRoleResponse>> GetAllAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<HierarchyByRoleResponse>>("api/v1/HierarchyByRole")
                    ?? new List<HierarchyByRoleResponse>();
         }
 
         public async Task<PaginatedResponse<HierarchyByRoleResponse>> GetByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/HierarchyByRole/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<HierarchyByRoleResponse>>(url)
                       ?? new PaginatedResponse<HierarchyByRoleResponse>();
@@ -37,11 +58,13 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<HierarchyByRoleResponse?> GetAsync(int id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<HierarchyByRoleResponse>($"api/v1/HierarchyByRole/{id}");
         }
 
         public async Task<int> CreateAsync(HierarchyByRoleRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/HierarchyByRole", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<int>();
@@ -49,6 +72,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(UpdateHierarchyByRoleRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/HierarchyByRole", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<bool>();
@@ -56,6 +80,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/HierarchyByRole/{id}");
             response.EnsureSuccessStatusCode();
         }

--- a/Farmacheck.Infrastructure/Services/PeriodicityByQuestionnaireApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/PeriodicityByQuestionnaireApiClient.cs
@@ -1,6 +1,8 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Common;
 using Farmacheck.Application.Models.PeriodicitiesByQuestionnaires;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -8,20 +10,38 @@ namespace Farmacheck.Infrastructure.Services
     public class PeriodicityByQuestionnaireApiClient : IPeriodicityByQuestionnaireApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public PeriodicityByQuestionnaireApiClient(HttpClient http)
+        public PeriodicityByQuestionnaireApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<List<PeriodicityByQuestionnaireResponse>> GetPeriodicitiesAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<PeriodicityByQuestionnaireResponse>>("api/v1/PeriodicityByQuestionnaire")
                    ?? new List<PeriodicityByQuestionnaireResponse>();
         }
 
         public async Task<PaginatedResponse<PeriodicityByQuestionnaireResponse>> GetPeriodicitiesByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/PeriodicityByQuestionnaire/pages?page={page}&items={items}";
             return await _http.GetFromJsonAsync<PaginatedResponse<PeriodicityByQuestionnaireResponse>>(url)
                    ?? new PaginatedResponse<PeriodicityByQuestionnaireResponse>();
@@ -29,6 +49,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<PeriodicityByQuestionnaireResponse?> GetPeriodicityAsync(int id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<PeriodicityByQuestionnaireResponse>($"api/v1/PeriodicityByQuestionnaire/{id}");
         }
 
@@ -36,6 +57,7 @@ namespace Farmacheck.Infrastructure.Services
         {
             try
             {
+                AddBearerToken();
                 var response = await _http.PostAsJsonAsync("api/v1/PeriodicityByQuestionnaire", request);
                 response.EnsureSuccessStatusCode();
 
@@ -44,7 +66,7 @@ namespace Farmacheck.Infrastructure.Services
            
             catch (Exception ex)
             {
-                // cualquier otro error (serialización, timeout, etc.)
+                // cualquier otro error (serializaciÃ³n, timeout, etc.)
                 Console.WriteLine($"Error en CreateAsync: {ex.Message}");
                 return false;
             }
@@ -54,6 +76,7 @@ namespace Farmacheck.Infrastructure.Services
         {
             try
             {
+                AddBearerToken();
                 var response = await _http.PutAsJsonAsync("api/v1/PeriodicityByQuestionnaire", request);
                 response.EnsureSuccessStatusCode();
 
@@ -70,6 +93,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/PeriodicityByQuestionnaire/{id}");
             response.EnsureSuccessStatusCode();
         }

--- a/Farmacheck.Infrastructure/Services/RolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/RolesApiClient.cs
@@ -1,6 +1,8 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Roles;
 using Farmacheck.Application.Models.Common;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -8,32 +10,52 @@ namespace Farmacheck.Infrastructure.Services
     public class RolesApiClient : IRoleApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public RolesApiClient(HttpClient http)
+        public RolesApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<IEnumerable<RoleResponse>> GetAllRolesAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<IEnumerable<RoleResponse>>("api/v1/Roles/all")
                    ?? Enumerable.Empty<RoleResponse>();
         }
 
         public async Task<IEnumerable<RoleResponse>> GetRolesByBusinessUnitAsync(byte businessUnitId)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<IEnumerable<RoleResponse>>($"api/v1/Roles/businessunit/{businessUnitId}")
                    ?? Enumerable.Empty<RoleResponse>();
         }
 
         public async Task<List<RoleResponse>> GetRolesAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<RoleResponse>>("api/v1/Roles")
                    ?? new List<RoleResponse>();
         }
 
         public async Task<PaginatedResponse<RoleResponse>> GetRolesByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/Roles/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<RoleResponse>>(url)
                       ?? new PaginatedResponse<RoleResponse>();
@@ -43,12 +65,14 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<RoleResponse?> GetRoleAsync(byte id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<RoleResponse>($"api/v1/Roles/{id}");
         }
 
         public async Task<RoleResponse?> GetRoleByNameAsync(string rolName)
         {
             try {
+                AddBearerToken();
                 return await _http.GetFromJsonAsync<RoleResponse>($"api/v1/Roles/name/{rolName}");
             }
             catch (Exception ex) {
@@ -59,6 +83,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<int> CreateAsync(RoleRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/Roles", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<int>();
@@ -66,6 +91,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(UpdateRoleRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/Roles", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<bool>();
@@ -73,12 +99,14 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(byte id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/Roles/{id}");
             response.EnsureSuccessStatusCode();
         }
 
         public async Task<string> GetReport()
         {
+            AddBearerToken();
             var response = await _http.GetAsync("api/v1/Roles/report");
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync();

--- a/Farmacheck.Infrastructure/Services/UsersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/UsersApiClient.cs
@@ -1,6 +1,8 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Users;
 using Farmacheck.Application.Models.Common;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -8,26 +10,45 @@ namespace Farmacheck.Infrastructure.Services
     public class UsersApiClient : IUserApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public UsersApiClient(HttpClient http)
+        public UsersApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<IEnumerable<UserResponse>> GetAllUsersAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<IEnumerable<UserResponse>>("api/v1/Users/all")
                    ?? Enumerable.Empty<UserResponse>();
         }
 
         public async Task<List<UserResponse>> GetUsersAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<UserResponse>>("api/v1/Users")
                    ?? new List<UserResponse>();
         }
 
         public async Task<PaginatedResponse<UserResponse>> GetUsersByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/Users/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<UserResponse>>(url)
                       ?? new PaginatedResponse<UserResponse>();
@@ -37,6 +58,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<UserResponse?> GetUserAsync(int id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<UserResponse>($"api/v1/Users/{id}");
         }
 
@@ -45,18 +67,20 @@ namespace Farmacheck.Infrastructure.Services
             try
             {
 
+                AddBearerToken();
                 var response = await _http.PostAsJsonAsync("api/v1/Users", request);
                 response.EnsureSuccessStatusCode();
                 return await response.Content.ReadFromJsonAsync<int>();
             }
             catch (Exception ex)
             {
-                throw new Exception("Ocurrió un error inesperado al crear el usuario.", ex);
+                throw new Exception("OcurriÃ³ un error inesperado al crear el usuario.", ex);
             }
         }
 
         public async Task<bool> UpdateAsync(UpdateUserRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/Users", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<bool>();
@@ -64,11 +88,13 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/Users/{id}");
             response.EnsureSuccessStatusCode();
         }
         public async Task<string> GetReport()
         {
+            AddBearerToken();
             var response = await _http.GetAsync("api/v1/Users/report");
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync();

--- a/Farmacheck.Infrastructure/Services/UsersByRolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/UsersByRolesApiClient.cs
@@ -1,6 +1,8 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Users;
 using Farmacheck.Application.Models.Common;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -8,20 +10,38 @@ namespace Farmacheck.Infrastructure.Services
     public class UsersByRolesApiClient : IUserByRoleApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public UsersByRolesApiClient(HttpClient http)
+        public UsersByRolesApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<List<UserByRoleResponse>> GetUsersByRolesAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<UserByRoleResponse>>("api/v1/UsersByRoles")
                    ?? new List<UserByRoleResponse>();
         }
 
         public async Task<PaginatedResponse<UserByRoleResponse>> GetUsersByRolesByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/UsersByRoles/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<UserByRoleResponse>>(url)
                       ?? new PaginatedResponse<UserByRoleResponse>();
@@ -31,17 +51,20 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<UserByRoleResponse?> GetUserByRoleAsync(int id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<UserByRoleResponse>($"api/v1/UsersByRoles/{id}");
         }
 
         public async Task<List<RelUserByRoleResponse>> GetByUserAsync(int usuarioId)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<RelUserByRoleResponse>>($"api/v1/UsersByRoles/user/{usuarioId}")
                    ?? new List<RelUserByRoleResponse>();
         }
 
         public async Task<int> CreateAsync(UserByRoleRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/UsersByRoles", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<int>();
@@ -49,6 +72,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(UpdateUserByRoleRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/UsersByRoles", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<bool>();
@@ -56,6 +80,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/UsersByRoles/{id}");
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<bool>();
@@ -63,6 +88,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<string> GetReport()
         {
+            AddBearerToken();
             var response = await _http.GetAsync("api/v1/UsersByRoles/report");
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
## Summary
- attach bearer token from AuthToken cookie in CategoryByQuestionnaire, PeriodicityByQuestionnaire, Roles, HierarchyByRoles, Users, and UsersByRoles API clients

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(command not found: dotnet)*
- `apt-get update` *(403 Forbidden when attempting to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f81ba5d88331b829b95dcf845bfe