### PR TITLE
Send bearer token with protected API requests

### DIFF
--- a/Farmacheck.Infrastructure/Services/ClientesAsignadosArolPorUsuariosApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/ClientesAsignadosArolPorUsuariosApiClient.cs
@@ -3,26 +3,46 @@ using Farmacheck.Application.Models.ClientesAsignadosArolPorUsuarios;
 using Farmacheck.Application.Models.Common;
 using System.Net.Http.Json;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 
 namespace Farmacheck.Infrastructure.Services
 {
     public class ClientesAsignadosArolPorUsuariosApiClient : IClientesAsignadosArolPorUsuariosApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public ClientesAsignadosArolPorUsuariosApiClient(HttpClient http)
+        public ClientesAsignadosArolPorUsuariosApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<List<ClientesAsignadosArolPorUsuarioResponse>> GetClientesAsignadosAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<ClientesAsignadosArolPorUsuarioResponse>>("api/v1/ClientesAsignadosArolPorUsuarios")
                    ?? new List<ClientesAsignadosArolPorUsuarioResponse>();
         }
 
         public async Task<PaginatedResponse<ClientesAsignadosArolPorUsuarioResponse>> GetClientesAsignadosByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/ClientesAsignadosArolPorUsuarios/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<ClientesAsignadosArolPorUsuarioResponse>>(url)
                       ?? new PaginatedResponse<ClientesAsignadosArolPorUsuarioResponse>();
@@ -32,11 +52,13 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<ClientesAsignadosArolPorUsuarioResponse?> GetClienteAsignadoAsync(int id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<ClientesAsignadosArolPorUsuarioResponse>($"api/v1/ClientesAsignadosArolPorUsuarios/{id}");
         }
 
         public async Task<List<RolPorUsuarioClientesAsignadosResponse>> GetCountByRolPorUsuarioAsync(List<int> rolPorUsuarioIds, int usuarioId)
         {
+            AddBearerToken();
             var query = string.Join("&", rolPorUsuarioIds.Select(id => $"rolPorUsuarioIds={id}"));
             var url = $"api/v1/ClientesAsignadosArolPorUsuarios/rolPorUsuario/usuario/{usuarioId}?{query}";
             return await _http.GetFromJsonAsync<List<RolPorUsuarioClientesAsignadosResponse>>(url)
@@ -45,6 +67,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<int> CreateAsync(ClientesAsignadosArolPorUsuarioRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/ClientesAsignadosArolPorUsuarios", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<int>();
@@ -52,6 +75,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(UpdateClientesAsignadosArolPorUsuarioRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/ClientesAsignadosArolPorUsuarios", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<bool>();
@@ -59,6 +83,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/ClientesAsignadosArolPorUsuarios/{id}");
             response.EnsureSuccessStatusCode();
         }


### PR DESCRIPTION
## Summary
- add bearer token injection for BusinessStructure API client
- add bearer token injection for quiz assignment manager client
- add bearer token injection for ClientesAsignadosArolPorUsuarios client

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fc68c130833183eeb0cc69954d04