### PR TITLE
Include bearer token in permission-related API clients

### DIFF
--- a/Farmacheck.Infrastructure/Services/CustomerTypesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CustomerTypesApiClient.cs
@@ -1,6 +1,8 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.CustomerTypes;
 using Farmacheck.Application.Models.Common;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -8,20 +10,38 @@ namespace Farmacheck.Infrastructure.Services
     public class CustomerTypesApiClient : ICustomerTypesApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public CustomerTypesApiClient(HttpClient http)
+        public CustomerTypesApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<List<CustomerTypeResponse>> GetCustomerTypesAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<CustomerTypeResponse>>("api/v1/CustomerTypes")
                    ?? new List<CustomerTypeResponse>();
         }
 
         public async Task<PaginatedResponse<CustomerTypeResponse>> GetCustomerTypesByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/CustomerTypes/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<CustomerTypeResponse>>(url)
                       ?? new PaginatedResponse<CustomerTypeResponse>();
@@ -31,11 +51,13 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<CustomerTypeResponse?> GetCustomerTypeAsync(int id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<CustomerTypeResponse>($"api/v1/CustomerTypes/{id}");
         }
 
         public async Task<int> CreateAsync(CustomerTypeRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/CustomerTypes", request);
             response.EnsureSuccessStatusCode();
 
@@ -44,6 +66,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(UpdateCustomerTypeRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/CustomerTypes", request);
             response.EnsureSuccessStatusCode();
 
@@ -52,6 +75,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/CustomerTypes/{id}");
             response.EnsureSuccessStatusCode();
         }

--- a/Farmacheck.Infrastructure/Services/PermissionByRolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/PermissionByRolesApiClient.cs
@@ -1,6 +1,8 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.PermissionsByRoles;
 using Farmacheck.Application.Models.Common;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -8,20 +10,38 @@ namespace Farmacheck.Infrastructure.Services
     public class PermissionByRolesApiClient : IPermissionByRoleApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public PermissionByRolesApiClient(HttpClient http)
+        public PermissionByRolesApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<List<PermissionByRoleResponse>> GetPermissionsByRolesAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<PermissionByRoleResponse>>("api/v1/PermissionsByRoles")
                    ?? new List<PermissionByRoleResponse>();
         }
 
         public async Task<PaginatedResponse<PermissionByRoleResponse>> GetPermissionsByRolesByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/PermissionsByRoles/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<PermissionByRoleResponse>>(url)
                       ?? new PaginatedResponse<PermissionByRoleResponse>();
@@ -31,17 +51,20 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<PermissionByRoleResponse?> GetPermissionByRoleAsync(int id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<PermissionByRoleResponse>($"api/v1/PermissionsByRoles/{id}");
         }
 
         public async Task<List<PermissionByRoleResponse>> GetByRolAsync(int rolId)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<PermissionByRoleResponse>>($"api/v1/PermissionsByRoles/rol/{rolId}")
                    ?? new List<PermissionByRoleResponse>();
         }
 
         public async Task<int> CreateAsync(PermissionByRoleRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/PermissionsByRoles", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<int>();
@@ -49,6 +72,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(UpdatePermissionByRoleRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/PermissionsByRoles", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<bool>();
@@ -56,6 +80,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/PermissionsByRoles/{id}");
             response.EnsureSuccessStatusCode();
         }

--- a/Farmacheck.Infrastructure/Services/PermissionsApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/PermissionsApiClient.cs
@@ -1,6 +1,8 @@
 using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Permissions;
 using Farmacheck.Application.Models.Common;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
 namespace Farmacheck.Infrastructure.Services
@@ -8,20 +10,38 @@ namespace Farmacheck.Infrastructure.Services
     public class PermissionsApiClient : IPermissionApiClient
     {
         private readonly HttpClient _http;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public PermissionsApiClient(HttpClient http)
+        public PermissionsApiClient(HttpClient http, IHttpContextAccessor httpContextAccessor)
         {
             _http = http;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private void AddBearerToken()
+        {
+            if (_http.DefaultRequestHeaders.Authorization != null)
+            {
+                return;
+            }
+
+            var token = _httpContextAccessor.HttpContext?.Request.Cookies["AuthToken"];
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public async Task<List<PermissionResponse>> GetPermissionsAsync()
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<List<PermissionResponse>>("api/v1/Permissions")
                    ?? new List<PermissionResponse>();
         }
 
         public async Task<PaginatedResponse<PermissionResponse>> GetPermissionsByPageAsync(int page, int items)
         {
+            AddBearerToken();
             var url = $"api/v1/Permissions/pages?page={page}&items={items}";
             var res = await _http.GetFromJsonAsync<PaginatedResponse<PermissionResponse>>(url)
                       ?? new PaginatedResponse<PermissionResponse>();
@@ -31,11 +51,13 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<PermissionResponse?> GetPermissionAsync(int id)
         {
+            AddBearerToken();
             return await _http.GetFromJsonAsync<PermissionResponse>($"api/v1/Permissions/{id}");
         }
 
         public async Task<int> CreateAsync(PermissionRequest request)
         {
+            AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/Permissions", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<int>();
@@ -43,6 +65,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<bool> UpdateAsync(UpdatePermissionRequest request)
         {
+            AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/Permissions", request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<bool>();
@@ -50,6 +73,7 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task DeleteAsync(int id)
         {
+            AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/Permissions/{id}");
             response.EnsureSuccessStatusCode();
         }


### PR DESCRIPTION
## Summary
- ensure CustomerTypes, PermissionByRoles and Permissions API clients attach AuthToken cookie as bearer header

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1040ddd6c8331a5ba4175fe23135d