### PR TITLE
Fix multi-client removal in role assignments

### DIFF
--- a/Farmacheck.Infrastructure/Services/CustomersRolesUsersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CustomersRolesUsersApiClient.cs
@@ -113,8 +113,8 @@ namespace Farmacheck.Infrastructure.Services
             try
             {
                 AddBearerToken();
-                var query = string.Join("&", ids.Select(id => $"ids={id}"));
-                var url = $"api/v1/Customers_RolesUsers/customer?{query}&customer={customer}";
+                var idsParam = string.Join(",", ids);
+                var url = $"api/v1/Customers_RolesUsers/customer?ids={idsParam}&customer={customer}";
 
                 var response = await _http.DeleteAsync(url);
 


### PR DESCRIPTION
## Summary
- ensure `RemoveByCustomerAsync` sends all IDs in a single comma-separated query

## Testing
- ⚠️ `dotnet build Farmacheck/Farmacheck.sln` *(command failed: bash: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68c7442ed7a483318f8b4434d128d082