### PR TITLE
Improve API client error handling

### DIFF
--- a/Farmacheck.Infrastructure/Services/CustomersRolesUsersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/CustomersRolesUsersApiClient.cs
@@ -80,24 +80,17 @@ namespace Farmacheck.Infrastructure.Services
 
         public async Task<string> CreateAsync(CustomerRolUserRequest request)
         {
-            try
-            {
-                AddBearerToken();
-                var response = await _http.PostAsJsonAsync("api/v1/Customers_RolesUsers", request);
-                response.EnsureSuccessStatusCode();
-                return await response.Content.ReadAsStringAsync();
-            }
-            catch (Exception ex)
-            {
-                throw new Exception(ex.Message);
-            }
+            AddBearerToken();
+            var response = await _http.PostAsJsonAsync("api/v1/Customers_RolesUsers", request);
+            await response.EnsureSuccessWithDetailsAsync();
+            return await response.Content.ReadAsStringAsync();
         }
 
         public async Task<bool> UpdateAsync(UpdateCustomerRolUserRequest request)
         {
             AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/Customers_RolesUsers", request);
-            response.EnsureSuccessStatusCode();
+            await response.EnsureSuccessWithDetailsAsync();
             return await response.Content.ReadFromJsonAsync<bool>();
         }
 
@@ -105,7 +98,7 @@ namespace Farmacheck.Infrastructure.Services
         {
             AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/Customers_RolesUsers/{id}");
-            response.EnsureSuccessStatusCode();
+            await response.EnsureSuccessWithDetailsAsync();
             return await response.Content.ReadFromJsonAsync<bool>();
         }
 
@@ -121,7 +114,7 @@ namespace Farmacheck.Infrastructure.Services
             var url = QueryHelpers.AddQueryString("api/v1/Customers_RolesUsers/customer", query);
 
             var response = await _http.DeleteAsync(url);
-            response.EnsureSuccessStatusCode();
+            await response.EnsureSuccessWithDetailsAsync();
 
             return await response.Content.ReadFromJsonAsync<bool>();
         }

--- a/Farmacheck.Infrastructure/Services/HttpResponseMessageExtensions.cs
+++ b/Farmacheck.Infrastructure/Services/HttpResponseMessageExtensions.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Farmacheck.Infrastructure.Services
+{
+    internal static class HttpResponseMessageExtensions
+    {
+        public static async Task EnsureSuccessWithDetailsAsync(this HttpResponseMessage response)
+        {
+            if (response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            var message = BuildErrorMessage(response, content);
+
+            throw new HttpRequestException(message);
+        }
+
+        private static string BuildErrorMessage(HttpResponseMessage response, string content)
+        {
+            var statusMessage = $"Request failed with status {(int)response.StatusCode} ({response.ReasonPhrase}).";
+            var details = ExtractErrorDetails(content);
+
+            if (string.IsNullOrWhiteSpace(details))
+            {
+                return statusMessage;
+            }
+
+            return $"{statusMessage} Details: {details}";
+        }
+
+        private static string ExtractErrorDetails(string content)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(content);
+                var root = document.RootElement;
+
+                if (root.TryGetProperty("errors", out var errorsElement))
+                {
+                    var messages = new List<string>();
+                    CollectMessages(errorsElement, messages);
+                    if (messages.Count > 0)
+                    {
+                        return string.Join(" | ", messages);
+                    }
+                }
+
+                if (root.TryGetProperty("message", out var messageProp) && messageProp.ValueKind == JsonValueKind.String)
+                {
+                    return messageProp.GetString() ?? string.Empty;
+                }
+
+                if (root.TryGetProperty("error", out var errorProp) && errorProp.ValueKind == JsonValueKind.String)
+                {
+                    return errorProp.GetString() ?? string.Empty;
+                }
+
+                if (root.TryGetProperty("title", out var titleProp) && titleProp.ValueKind == JsonValueKind.String)
+                {
+                    return titleProp.GetString() ?? string.Empty;
+                }
+            }
+            catch (JsonException)
+            {
+                // If the content is not valid JSON we just fall back to returning the raw text.
+            }
+
+            return content;
+        }
+
+        private static void CollectMessages(JsonElement element, List<string> messages)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.String:
+                    var value = element.GetString();
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        messages.Add(value);
+                    }
+                    break;
+                case JsonValueKind.Array:
+                    foreach (var item in element.EnumerateArray())
+                    {
+                        CollectMessages(item, messages);
+                    }
+                    break;
+                case JsonValueKind.Object:
+                    foreach (var property in element.EnumerateObject())
+                    {
+                        CollectMessages(property.Value, messages);
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/Farmacheck.Infrastructure/Services/UsersByRolesApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/UsersByRolesApiClient.cs
@@ -66,7 +66,7 @@ namespace Farmacheck.Infrastructure.Services
         {
             AddBearerToken();
             var response = await _http.PostAsJsonAsync("api/v1/UsersByRoles", request);
-            response.EnsureSuccessStatusCode();
+            await response.EnsureSuccessWithDetailsAsync();
             return await response.Content.ReadFromJsonAsync<int>();
         }
 
@@ -74,7 +74,7 @@ namespace Farmacheck.Infrastructure.Services
         {
             AddBearerToken();
             var response = await _http.PutAsJsonAsync("api/v1/UsersByRoles", request);
-            response.EnsureSuccessStatusCode();
+            await response.EnsureSuccessWithDetailsAsync();
             return await response.Content.ReadFromJsonAsync<bool>();
         }
 
@@ -82,7 +82,7 @@ namespace Farmacheck.Infrastructure.Services
         {
             AddBearerToken();
             var response = await _http.DeleteAsync($"api/v1/UsersByRoles/{id}");
-            response.EnsureSuccessStatusCode();
+            await response.EnsureSuccessWithDetailsAsync();
             return await response.Content.ReadFromJsonAsync<bool>();
         }
 
@@ -90,7 +90,7 @@ namespace Farmacheck.Infrastructure.Services
         {
             AddBearerToken();
             var response = await _http.GetAsync("api/v1/UsersByRoles/report");
-            response.EnsureSuccessStatusCode();
+            await response.EnsureSuccessWithDetailsAsync();
             return await response.Content.ReadAsStringAsync();
         }
     }


### PR DESCRIPTION
## Summary
- replace direct EnsureSuccessStatusCode calls with a helper that surfaces API error details
- add an HttpResponseMessage extension to parse error payloads and include them in thrown exceptions
- propagate the enhanced error handling to customer role and user role API clients

## Testing
- dotnet build Farmacheck/Farmacheck.sln *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d618b0481883319e811c48cca91821