### PR TITLE
Ordena alfabeticamente selects de usuario

### DIFF
--- a/Farmacheck/Controllers/RolController.cs
+++ b/Farmacheck/Controllers/RolController.cs
@@ -43,7 +43,9 @@ namespace Farmacheck.Controllers
 
             var apiData = await _apiClient.GetAllRolesAsync();
             var dtos = _mapper.Map<List<RoleDto>>(apiData);
-            var roles = _mapper.Map<List<RolViewModel>>(dtos);
+            var roles = _mapper.Map<List<RolViewModel>>(dtos)
+                .OrderBy(r => r.Nombre ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             var unidadesApi = await _businessUnitApi.GetBusinessUnitsAsync();
             foreach (var r in roles)
@@ -60,7 +62,9 @@ namespace Farmacheck.Controllers
         {
             var apiData = await _apiClient.GetAllRolesAsync();
             var dtos = _mapper.Map<List<RoleDto>>(apiData);
-            var roles = _mapper.Map<List<RolViewModel>>(dtos);
+            var roles = _mapper.Map<List<RolViewModel>>(dtos)
+                .OrderBy(r => r.Nombre ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             var unidadesApi = await _businessUnitApi.GetBusinessUnitsAsync();
             foreach (var r in roles)
@@ -77,7 +81,9 @@ namespace Farmacheck.Controllers
         {
             var apiData = await _apiClient.GetRolesByBusinessUnitAsync((byte)unidadId);
             var dtos = _mapper.Map<List<RoleDto>>(apiData);
-            var roles = _mapper.Map<List<RolViewModel>>(dtos);
+            var roles = _mapper.Map<List<RolViewModel>>(dtos)
+                .OrderBy(r => r.Nombre ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             var unidadesApi = await _businessUnitApi.GetBusinessUnitsAsync();
             foreach (var r in roles)

--- a/Farmacheck/Controllers/UsuarioController.cs
+++ b/Farmacheck/Controllers/UsuarioController.cs
@@ -85,7 +85,9 @@ namespace Farmacheck.Controllers
         {
             var apiData = await _businessUnitApi.GetBusinessUnitsAsync();
             var dtos = _mapper.Map<List<BusinessUnitDto>>(apiData);
-            var unidades = _mapper.Map<List<UnidadDeNegocio>>(dtos);
+            var unidades = _mapper.Map<List<UnidadDeNegocio>>(dtos)
+                .OrderBy(u => u.Nombre ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             return Json(new { success = true, data = unidades });
         }


### PR DESCRIPTION
## Summary
- ordena las unidades de negocio devueltas por el controlador de usuarios por nombre
- ordena los roles devueltos por el controlador de roles por nombre para el modal de usuario

## Testing
- `dotnet build Farmacheck/Farmacheck.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d776870f608331a8def09db3a657f7