### PR TITLE
Add email-based lookup to Users API client

### DIFF
--- a/Farmacheck.Application/Interfaces/IUserApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IUserApiClient.cs
@@ -9,6 +9,7 @@ namespace Farmacheck.Application.Interfaces
         Task<List<UserResponse>> GetUsersAsync();
         Task<PaginatedResponse<UserResponse>> GetUsersByPageAsync(int page, int items);
         Task<UserResponse?> GetUserAsync(int id);
+        Task<UserResponse?> GetUserByEmailAsync(string email);
         Task<int> CreateAsync(UserRequest request);
         Task<bool> UpdateAsync(UpdateUserRequest request);
         Task DeleteAsync(int id);

--- a/Farmacheck.Infrastructure/Services/UsersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/UsersApiClient.cs
@@ -2,6 +2,8 @@ using Farmacheck.Application.Interfaces;
 using Farmacheck.Application.Models.Users;
 using Farmacheck.Application.Models.Common;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using System.Collections.Generic;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
@@ -60,6 +62,17 @@ namespace Farmacheck.Infrastructure.Services
         {
             AddBearerToken();
             return await _http.GetFromJsonAsync<UserResponse>($"api/v1/Users/{id}");
+        }
+
+        public async Task<UserResponse?> GetUserByEmailAsync(string email)
+        {
+            AddBearerToken();
+            var url = QueryHelpers.AddQueryString("api/v1/Users/by-email", new Dictionary<string, string?>
+            {
+                ["email"] = email,
+            });
+
+            return await _http.GetFromJsonAsync<UserResponse>(url);
         }
 
         public async Task<int> CreateAsync(UserRequest request)


### PR DESCRIPTION
## Summary
- expose a new IUserApiClient method to fetch users by email
- implement the UsersApiClient call to the API's by-email endpoint, including query construction

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dccd1b0a78833198942814d08a634b