### PR TITLE
Show password update modal when password change is required

### DIFF
--- a/Farmacheck/Controllers/AuthController.cs
+++ b/Farmacheck/Controllers/AuthController.cs
@@ -13,11 +13,13 @@ public class AuthController : Controller
 {
     private readonly IAuthApiClient _apiClient;
     private readonly IMapper _mapper;
+    private readonly IUserApiClient _userApiClient;
 
-    public AuthController(IAuthApiClient apiClient, IMapper mapper)
+    public AuthController(IAuthApiClient apiClient, IMapper mapper, IUserApiClient userApiClient)
     {
         _apiClient = apiClient;
         _mapper = mapper;
+        _userApiClient = userApiClient;
     }
 
     [HttpGet]
@@ -73,6 +75,30 @@ public class AuthController : Controller
             Response.Cookies.Append("AuthToken", vm.Token, cookieOptions);
 
             return Json(new { success = true, data = vm });
+        }
+        catch (Exception ex)
+        {
+            return Json(new { success = false, error = ex.Message });
+        }
+    }
+
+    [HttpGet]
+    public async Task<JsonResult> GetUserByEmail(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return Json(new { success = false, error = "Correo electrónico requerido" });
+        }
+
+        try
+        {
+            var user = await _userApiClient.GetUserByEmailAsync(email);
+            if (user == null)
+            {
+                return Json(new { success = false, error = "Usuario no encontrado" });
+            }
+
+            return Json(new { success = true, data = new { actualizaPass = user.ActualizaPass } });
         }
         catch (Exception ex)
         {

--- a/Farmacheck/Views/Security/Login.cshtml
+++ b/Farmacheck/Views/Security/Login.cshtml
@@ -87,71 +87,57 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script>
-        document.getElementById('loginForm').addEventListener('submit', async function (e) {
-            e.preventDefault();
+        let passwordModal;
+        let allowModalClose = false;
+        let redirectAfterModal = false;
 
-            const email = document.getElementById('email').value;
-            const password = document.getElementById('password').value;
-            console.log(email + ' - ' + password);
-            const response = await fetch('@Url.Action("Login", "Auth")', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                credentials: 'include',
-                body: JSON.stringify({ email: email, password: password })
-            });
-
-            const result = await response.json();
-            if (response.ok && result.success && result.data && result.data.token) {
-                console.log('1');
-                localStorage.setItem('username', email);
-                localStorage.setItem('token', result.data.token);
-                window.location.href = '@Url.Action("Index", "Formularios")';
-            } else {
-                console.log('2');
-                const message = (response.ok && result.success)
-                    ? 'Autenticación incorrecta, verificar mail o contraseña'
-                    : (result.error || 'Error al iniciar sesión');
-
-                Swal.fire({
-                    icon: 'error',
-                    title: 'Error',
-                    text: message
+        const needsPasswordUpdate = async (email) => {
+            try {
+                const response = await fetch('@Url.Action("GetUserByEmail", "Auth")' + `?email=${encodeURIComponent(email)}`, {
+                    method: 'GET',
+                    credentials: 'include'
                 });
-            }
-        });
 
-        document.getElementById('togglePassword').addEventListener('click', function () {
-            const passwordInput = document.getElementById('password');
-            const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
-            passwordInput.setAttribute('type', type);
-            this.classList.toggle('bi-eye');
-            this.classList.toggle('bi-eye-slash');
-        });
+                if (!response.ok) {
+                    return false;
+                }
+
+                const result = await response.json();
+                return result.success && result.data && result.data.actualizaPass === true;
+            } catch (error) {
+                console.error('Error al obtener información del usuario:', error);
+                return false;
+            }
+        };
 
         document.addEventListener('DOMContentLoaded', function () {
+            const loginForm = document.getElementById('loginForm');
             const modalElement = document.getElementById('passwordUpdateModal');
-            const passwordModal = new bootstrap.Modal(modalElement, {
+
+            passwordModal = new bootstrap.Modal(modalElement, {
                 backdrop: 'static',
                 keyboard: false
             });
-
-            let allowModalClose = false;
 
             modalElement.addEventListener('hide.bs.modal', function (event) {
                 if (!allowModalClose) {
                     event.preventDefault();
                 } else {
                     allowModalClose = false;
+                    if (redirectAfterModal) {
+                        redirectAfterModal = false;
+                        window.location.href = '@Url.Action("Index", "Formularios")';
+                    }
                 }
             });
-
-            passwordModal.show();
 
             const toggleVisibility = (toggleId, inputId) => {
                 const toggle = document.getElementById(toggleId);
                 const input = document.getElementById(inputId);
+
+                if (!toggle || !input) {
+                    return;
+                }
 
                 toggle.addEventListener('click', function () {
                     const type = input.getAttribute('type') === 'password' ? 'text' : 'password';
@@ -161,8 +147,50 @@
                 });
             };
 
+            toggleVisibility('togglePassword', 'password');
             toggleVisibility('toggleNewPassword', 'newPassword');
             toggleVisibility('toggleConfirmPassword', 'confirmPassword');
+
+            loginForm.addEventListener('submit', async function (e) {
+                e.preventDefault();
+
+                const email = document.getElementById('email').value;
+                const password = document.getElementById('password').value;
+
+                const response = await fetch('@Url.Action("Login", "Auth")', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    credentials: 'include',
+                    body: JSON.stringify({ email: email, password: password })
+                });
+
+                const result = await response.json();
+                if (response.ok && result.success && result.data && result.data.token) {
+                    localStorage.setItem('username', email);
+                    localStorage.setItem('token', result.data.token);
+
+                    const mustUpdatePassword = await needsPasswordUpdate(email);
+                    if (mustUpdatePassword) {
+                        redirectAfterModal = true;
+                        passwordModal.show();
+                        return;
+                    }
+
+                    window.location.href = '@Url.Action("Index", "Formularios")';
+                } else {
+                    const message = (response.ok && result.success)
+                        ? 'Autenticación incorrecta, verificar mail o contraseña'
+                        : (result.error || 'Error al iniciar sesión');
+
+                    Swal.fire({
+                        icon: 'error',
+                        title: 'Error',
+                        text: message
+                    });
+                }
+            });
 
             document.getElementById('updatePasswordButton').addEventListener('click', function () {
                 allowModalClose = true;


### PR DESCRIPTION
## Summary
- inject the user API client into the auth controller and expose an endpoint to retrieve the ActualizaPass flag by email
- keep the password update modal hidden on load and display it only when the authenticated user must update the password
- ensure the login flow queries the new endpoint after a successful sign-in and redirects only when no password update is required

## Testing
- ⚠️ `dotnet build Farmacheck/Farmacheck.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd79158a6c8331acd033f893f70b69