### PR TITLE
Align password update flag with API naming

### DIFF
--- a/Farmacheck.Application/DTOs/UserDto.cs
+++ b/Farmacheck.Application/DTOs/UserDto.cs
@@ -11,7 +11,7 @@ namespace Farmacheck.Application.DTOs
         public bool Estatus { get; set; }
         public DateTime CreadoEl { get; set; }
         public DateTime ActualizadoEl { get; set; }
-        public bool ActualizaPass { get; set; }
+        public bool ActualizarPass { get; set; }
         public bool GeolocalizacionActiva { get; set; }
     }
 }

--- a/Farmacheck.Application/Models/Users/UpdateUserRequest.cs
+++ b/Farmacheck.Application/Models/Users/UpdateUserRequest.cs
@@ -12,7 +12,7 @@ namespace Farmacheck.Application.Models.Users
         public string Email { get; set; }
         public long? NumeroDeTelefono { get; set; }
         public bool Estatus { get; set; }
-        public bool ActualizaPass { get; set; }
+        public bool ActualizarPass { get; set; }
         public bool GeolocalizacionActiva { get; set; }
     }
 }

--- a/Farmacheck.Application/Models/Users/UserResponse.cs
+++ b/Farmacheck.Application/Models/Users/UserResponse.cs
@@ -11,7 +11,7 @@ namespace Farmacheck.Application.Models.Users
         public bool Estatus { get; set; }
         public DateTime CreadoEl { get; set; }
         public DateTime ActualizadoEl { get; set; }
-        public bool ActualizaPass { get; set; }
+        public bool ActualizarPass { get; set; }
         public bool GeolocalizacionActiva { get; set; }
     }
 }

--- a/Farmacheck/Controllers/AuthController.cs
+++ b/Farmacheck/Controllers/AuthController.cs
@@ -98,7 +98,7 @@ public class AuthController : Controller
                 return Json(new { success = false, error = "Usuario no encontrado" });
             }
 
-            return Json(new { success = true, data = new { actualizaPass = user.ActualizaPass } });
+            return Json(new { success = true, data = new { actualizarPass = user.ActualizarPass } });
         }
         catch (Exception ex)
         {

--- a/Farmacheck/Models/UsuarioViewModel.cs
+++ b/Farmacheck/Models/UsuarioViewModel.cs
@@ -11,7 +11,7 @@ namespace Farmacheck.Models
         public bool Estatus { get; set; }
         public DateTime CreadoEl { get; set; }
         public DateTime ActualizadoEl { get; set; }
-        public bool ActualizaPass { get; set; }
+        public bool ActualizarPass { get; set; }
         public bool GeolocalizacionActiva { get; set; }
     }
 }

--- a/Farmacheck/Views/Security/Login.cshtml
+++ b/Farmacheck/Views/Security/Login.cshtml
@@ -103,7 +103,7 @@
                 }
 
                 const result = await response.json();
-                return result.success && result.data && result.data.actualizaPass === true;
+                return result.success && result.data && result.data.actualizarPass === true;
             } catch (error) {
                 console.error('Error al obtener información del usuario:', error);
                 return false;


### PR DESCRIPTION
## Summary
- rename the password update flag to `ActualizarPass` across DTOs, responses and view models to match the API contract
- update the authentication controller and login view to emit and read the corrected JSON property name

## Testing
- dotnet build Farmacheck/Farmacheck.sln *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd866229308331896472fc30830967