### PR TITLE
Add user password update endpoint to client

### DIFF
--- a/Farmacheck.Application/Interfaces/IUserApiClient.cs
+++ b/Farmacheck.Application/Interfaces/IUserApiClient.cs
@@ -12,6 +12,7 @@ namespace Farmacheck.Application.Interfaces
         Task<UserResponse?> GetUserByEmailAsync(string email);
         Task<int> CreateAsync(UserRequest request);
         Task<bool> UpdateAsync(UpdateUserRequest request);
+        Task<bool> UpdatePasswordAsync(UpdateUserPasswordRequest request);
         Task DeleteAsync(int id);
         Task<string> GetReport();
     }

--- a/Farmacheck.Application/Models/Users/UpdateUserPasswordRequest.cs
+++ b/Farmacheck.Application/Models/Users/UpdateUserPasswordRequest.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Farmacheck.Application.Models.Users
+{
+    public class UpdateUserPasswordRequest
+    {
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/Farmacheck.Infrastructure/Services/UsersApiClient.cs
+++ b/Farmacheck.Infrastructure/Services/UsersApiClient.cs
@@ -99,6 +99,14 @@ namespace Farmacheck.Infrastructure.Services
             return await response.Content.ReadFromJsonAsync<bool>();
         }
 
+        public async Task<bool> UpdatePasswordAsync(UpdateUserPasswordRequest request)
+        {
+            AddBearerToken();
+            var response = await _http.PostAsJsonAsync("api/v1/Users/password", request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<bool>();
+        }
+
         public async Task DeleteAsync(int id)
         {
             AddBearerToken();


### PR DESCRIPTION
## Summary
- add the UpdateUserPasswordRequest model for client requests
- expose an UpdatePasswordAsync method on IUserApiClient
- call the new API password endpoint from UsersApiClient

## Testing
- dotnet build Farmacheck/Farmacheck.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68de0d8abd0c8331b7abb5058455c15b