### PR TITLE
Fix password update modal flag check

### DIFF
--- a/Farmacheck/Views/Security/Login.cshtml
+++ b/Farmacheck/Views/Security/Login.cshtml
@@ -104,7 +104,7 @@
                 }
 
                 const result = await response.json();
-                return result.success && result.data && result.data.actualizarPass === true;
+                return result.success && result.data && result.data.actualizaPass === true;
             } catch (error) {
                 console.error('Error al obtener información del usuario:', error);
                 return false;


### PR DESCRIPTION
## Summary
- ensure the login flow reads the password update flag returned by the API using the correct property name

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de20e2a2348331b1399abf7f6a3933